### PR TITLE
Fixed problem that looks like speckled cascades shadow when using original Z.

### DIFF
--- a/Editor/ImGui/Implementation/ImGui_RHI.h
+++ b/Editor/ImGui/Implementation/ImGui_RHI.h
@@ -96,6 +96,7 @@ namespace ImGui::RHI
 			    g_rhi_device,
 			    Cull_None,
 			    Fill_Solid,
+                false,  // front counter clock wise
 			    true,	// depth clip
 			    true,	// scissor
 			    false,	// multi-sample

--- a/Runtime/RHI/D3D11/D3D11_RasterizerState.cpp
+++ b/Runtime/RHI/D3D11/D3D11_RasterizerState.cpp
@@ -41,6 +41,7 @@ namespace Spartan
 		const shared_ptr<RHI_Device>& rhi_device,
 		const RHI_Cull_Mode cull_mode,
 		const RHI_Fill_Mode fill_mode,
+        const bool front_counter_clock_wise,
 		const bool depth_clip_enabled,
 		const bool scissor_enabled,
 		const bool multi_sample_enabled,
@@ -61,6 +62,7 @@ namespace Spartan
 		// Save properties
 		m_cull_mode					= cull_mode;
 		m_fill_mode					= fill_mode;
+        m_front_counter_clock_wise  = front_counter_clock_wise;
 		m_depth_clip_enabled		= depth_clip_enabled;
 		m_scissor_enabled			= scissor_enabled;
 		m_multi_sample_enabled		= multi_sample_enabled;
@@ -70,7 +72,7 @@ namespace Spartan
 		D3D11_RASTERIZER_DESC desc;
 		desc.CullMode				= d3d11_cull_mode[cull_mode];
 		desc.FillMode				= d3d11_polygon_mode[fill_mode];	
-		desc.FrontCounterClockwise	= false;
+		desc.FrontCounterClockwise	= front_counter_clock_wise;
 		desc.DepthBias				= 0;
 		desc.DepthBiasClamp			= 0.0f;
 		desc.SlopeScaledDepthBias	= 0.0f;

--- a/Runtime/RHI/RHI_RasterizerState.h
+++ b/Runtime/RHI/RHI_RasterizerState.h
@@ -36,6 +36,7 @@ namespace Spartan
 			const std::shared_ptr<RHI_Device>& rhi_device,
 			RHI_Cull_Mode cull_mode,
 			RHI_Fill_Mode fill_mode,
+            bool front_counter_clock_wise,
 			bool depth_clip_enabled,
 			bool scissor_enabled,
 			bool multi_sample_enabled, 
@@ -45,6 +46,7 @@ namespace Spartan
 
 		auto GetCullMode()				const { return m_cull_mode; }
 		auto GetFillMode()				const { return m_fill_mode; }
+        auto GetFrontCounterClockWise() const { return m_front_counter_clock_wise; }
 		auto GetDepthClipEnabled()		const { return m_depth_clip_enabled; }
 		auto GetScissorEnabled()		const { return m_scissor_enabled; }
 		auto GetMultiSampleEnabled()	const { return m_multi_sample_enabled; }
@@ -57,6 +59,7 @@ namespace Spartan
 			return
 				m_cull_mode == rhs.GetCullMode() &&
 				m_fill_mode == rhs.GetFillMode() &&
+                m_front_counter_clock_wise == rhs.GetFrontCounterClockWise() &&
 				m_depth_clip_enabled == rhs.GetDepthClipEnabled() &&
 				m_scissor_enabled == rhs.GetScissorEnabled() &&
 				m_multi_sample_enabled == rhs.GetMultiSampleEnabled() &&
@@ -67,6 +70,7 @@ namespace Spartan
 		// Properties
 		RHI_Cull_Mode m_cull_mode;
 		RHI_Fill_Mode m_fill_mode;
+        bool m_front_counter_clock_wise;
 		bool m_depth_clip_enabled;
 		bool m_scissor_enabled;
 		bool m_multi_sample_enabled;

--- a/Runtime/Rendering/Renderer.cpp
+++ b/Runtime/Rendering/Renderer.cpp
@@ -171,12 +171,13 @@ namespace Spartan
 
 	void Renderer::CreateRasterizerStates()
 	{
-		m_rasterizer_cull_back_solid		= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_Back,		Fill_Solid,		true, false, false, false);
-		m_rasterizer_cull_front_solid		= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_Front,	Fill_Solid,		true, false, false, false);
-		m_rasterizer_cull_none_solid		= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_None,		Fill_Solid,		true, false, false, false);
-		m_rasterizer_cull_back_wireframe	= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_Back,		Fill_Wireframe,	true, false, false, true);
-		m_rasterizer_cull_front_wireframe	= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_Front,	Fill_Wireframe,	true, false, false, true);
-		m_rasterizer_cull_none_wireframe	= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_None,		Fill_Wireframe,	true, false, false, true);
+		m_rasterizer_cull_back_solid		= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_Back,		Fill_Solid,		false, true, false, false, false);
+		m_rasterizer_cull_front_solid		= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_Front,	Fill_Solid,		false, true, false, false, false);
+		m_rasterizer_cull_none_solid		= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_None,		Fill_Solid,		false, true, false, false, false);
+		m_rasterizer_cull_back_wireframe	= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_Back,		Fill_Wireframe,	false, true, false, false, true);
+		m_rasterizer_cull_front_wireframe	= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_Front,	Fill_Wireframe,	false, true, false, false, true);
+		m_rasterizer_cull_none_wireframe	= make_shared<RHI_RasterizerState>(m_rhi_device, Cull_None,		Fill_Wireframe,	false, true, false, false, true);
+        m_rasterizer_cull_back_ccw_solid    = make_shared<RHI_RasterizerState>(m_rhi_device, Cull_Back,     Fill_Solid,     true,  true, false, false, true);
 	}
 
 	void Renderer::CreateBlendStates()

--- a/Runtime/Rendering/Renderer.h
+++ b/Runtime/Rendering/Renderer.h
@@ -367,6 +367,7 @@ namespace Spartan
 		std::shared_ptr<RHI_RasterizerState> m_rasterizer_cull_back_wireframe;
 		std::shared_ptr<RHI_RasterizerState> m_rasterizer_cull_front_wireframe;
 		std::shared_ptr<RHI_RasterizerState> m_rasterizer_cull_none_wireframe;
+        std::shared_ptr<RHI_RasterizerState> m_rasterizer_cull_back_ccw_solid;
 		//=====================================================================
 
 		//= SAMPLERS ===========================================
@@ -412,7 +413,7 @@ namespace Spartan
 		Renderer_Buffer_Type m_debug_buffer         = Renderer_Buffer_None;
 		uint32_t m_flags                            = 0;
 		bool m_initialized                          = false;
-        bool m_reverse_z                            = true;
+        bool m_reverse_z                            = false;
         uint32_t m_resolution_shadow                = 4096;
         uint32_t m_resolution_shadow_min            = 128;
         uint32_t m_anisotropy                       = 16;

--- a/Runtime/Rendering/Renderer_Passes.cpp
+++ b/Runtime/Rendering/Renderer_Passes.cpp
@@ -119,7 +119,7 @@ namespace Spartan
 			m_cmd_list->SetShaderPixel(nullptr);
 			m_cmd_list->SetBlendState(m_blend_disabled);
 			m_cmd_list->SetDepthStencilState(m_depth_stencil_enabled);
-			m_cmd_list->SetRasterizerState(m_rasterizer_cull_back_solid);
+            m_cmd_list->SetRasterizerState(GetReverseZ() ? m_rasterizer_cull_back_solid : m_rasterizer_cull_back_ccw_solid);
 			m_cmd_list->SetPrimitiveTopology(PrimitiveTopology_TriangleList);
 			m_cmd_list->SetShaderVertex(shader_depth);
 			m_cmd_list->SetInputLayout(shader_depth->GetInputLayout());


### PR DESCRIPTION
Hello. I ordinarily use my own repository. so misunderstood how to push other repository.
I thought that I push perfectly to your repository..😂😂

**The Main Body**
When using original Z, It occurs odd cascade shadow. I found out a solution after several attempts. 
This is because the front face was recognized as the rear face and was drawn as the opposite.


**Solution**
1. add other rasterizer_state that front counter clock wise is true.
2. When rendering light depth texture, if Z is original, set rasterizer state m_cull_back_ccw_solid, not m_cull_back_solid.

That's it. It took me hours to find a solution, but it's simple. that makes me sad.

[Problem]
![63816971-2aec5a00-c975-11e9-8fd8-7eb8e3cd8c9f](https://user-images.githubusercontent.com/54325338/63877784-3be3ac80-ca03-11e9-9efd-0a53c90398fb.jpg)

![63816976-30e23b00-c975-11e9-9d36-7e93c4dcd939](https://user-images.githubusercontent.com/54325338/63877792-4140f700-ca03-11e9-8fec-d93ad16030f7.jpg)


[Fixed]
![63816623-dac0c800-c973-11e9-82a6-9e824c1b34d7](https://user-images.githubusercontent.com/54325338/63877812-4aca5f00-ca03-11e9-9e30-1b5d32db66a9.jpg)






P.S I'm learning a lot from your wonderful work. Thank you!