### PR TITLE
[Premake] Create different visual studio solutions and project files for each graphics API

### DIFF
--- a/.github/workflows/windows_d3d11.yml
+++ b/.github/workflows/windows_d3d11.yml
@@ -19,11 +19,11 @@ jobs:
           
       - name: Build
         shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" /p:Platform=Windows /p:Configuration=Release /m Spartan.sln'
+        run: '"%MSBUILD_PATH%\MSBuild.exe" /p:Platform=Windows /p:Configuration=Release /m Spartan_d3d11.sln'
           
       - name: Clean up for artifact upload
         shell: bash
-        run: ./Scripts/clean.sh
+        run: ./Scripts/clean.sh d3d11
  
       - uses: actions/upload-artifact@master  
         with:

--- a/.github/workflows/windows_d3d12.yml
+++ b/.github/workflows/windows_d3d12.yml
@@ -19,11 +19,11 @@ jobs:
           
       - name: Build
         shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" /p:Platform=Windows /p:Configuration=Release /m Spartan.sln'
+        run: '"%MSBUILD_PATH%\MSBuild.exe" /p:Platform=Windows /p:Configuration=Release /m Spartan_d3d12.sln'
           
       - name: Clean up for artifact upload
         shell: bash
-        run: ./Scripts/clean.sh
+        run: ./Scripts/clean.sh d3d12
  
       - uses: actions/upload-artifact@master  
         with:

--- a/.github/workflows/windows_vulkan.yml
+++ b/.github/workflows/windows_vulkan.yml
@@ -19,11 +19,11 @@ jobs:
           
       - name: Build
         shell: cmd
-        run: '"%MSBUILD_PATH%\MSBuild.exe" /p:Platform=Windows /p:Configuration=Release /m Spartan.sln'
+        run: '"%MSBUILD_PATH%\MSBuild.exe" /p:Platform=Windows /p:Configuration=Release /m Spartan_vulkan.sln'
           
       - name: Clean up for artifact upload
         shell: bash
-        run: ./Scripts/clean.sh
+        run: ./Scripts/clean.sh vulkan
  
       - uses: actions/upload-artifact@master  
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,4 @@ ModelManifest.xml
 .fake/
 
 .vscode/
+*.bak

--- a/Scripts/clean.sh
+++ b/Scripts/clean.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # delete obj directory
-rm -rf Binaries/Obj
+rm -rf "Binaries/Obj/$1"
 
 # delete exe directory files (that don't need to be part of build artifacts)
-rm -f Binaries/*.exp
-rm -f Binaries/*.ilk
-rm -f Binaries/*.lib
-rm -f Binaries/*.pdb
+rm -f "Binaries/$1/*.exp"
+rm -f "Binaries/$1/*.ilk"
+rm -f "Binaries/$1/*.lib"
+rm -f "Binaries/$1/*.pdb"
 
 # delete debug dlls (in case they exist)
-rm -rf Binaries/fmodL64.dll
+rm -rf "Binaries/$1/fmodL64.dll"

--- a/Scripts/generate_project_files.sh
+++ b/Scripts/generate_project_files.sh
@@ -8,7 +8,7 @@ fi
 
 # Delete any files which are not needed for a CI artifact to be created
 echo "1. Deleting uncessery files from the binary directory..."
-./Scripts/clean.sh
+./Scripts/clean.sh $2
 
 # Extract third-party libraries (that the project will link to)
 echo
@@ -23,15 +23,15 @@ echo "==========================================================================
 # Copy engine data to the binary directory
 echo
 echo "3. Copying required data to the binary directory..."
-mkdir -p Binaries/
-cp -r Data Binaries
+mkdir -p "Binaries/$2"
+cp -r Data "Binaries/$2"
 
 # Copy engine DLLs to the binary directory
 echo
 echo "4. Copying required DLLs to the binary directory..."
-cp ThirdParty/libraries/dxcompiler.dll Binaries/
-cp ThirdParty/libraries/fmod64.dll Binaries/
-cp ThirdParty/libraries/fmodL64.dll	Binaries/
+cp ThirdParty/libraries/dxcompiler.dll "Binaries/$2"
+cp ThirdParty/libraries/fmod64.dll "Binaries/$2"
+cp ThirdParty/libraries/fmodL64.dll	"Binaries/$2"
 
 # Generate project files
 echo

--- a/Scripts/premake.lua
+++ b/Scripts/premake.lua
@@ -28,24 +28,30 @@ ADDITIONAL_INCLUDES      = {}
 ADDITIONAL_LIBRARIES     = {}
 ADDITIONAL_LIBRARIES_DBG = {}
 LIBRARY_DIR              = "../ThirdParty/libraries"
-OBJ_DIR                  = "../Binaries/Obj"
-TARGET_DIR               = "../Binaries"
 API_GRAPHICS             = _ARGS[1]
+TARGET_DIR               = "../Binaries/" .. API_GRAPHICS
+OBJ_DIR                  = "../Binaries/Obj/" .. API_GRAPHICS
 
 -- Graphics api specific variables
 if API_GRAPHICS == "d3d11" then
 	API_GRAPHICS                = "API_GRAPHICS_D3D11"
 	TARGET_NAME                 = TARGET_NAME .. "_d3d11"
+	SOLUTION_NAME				= SOLUTION_NAME .. "_d3d11"
+	RUNTIME_NAME             	= RUNTIME_NAME .. "_d3d11"
 	IGNORE_FILES[0]	            = RUNTIME_DIR .. "/RHI/D3D12/**"
 	IGNORE_FILES[1]	            = RUNTIME_DIR .. "/RHI/Vulkan/**"
 elseif API_GRAPHICS == "d3d12" then
 	API_GRAPHICS                = "API_GRAPHICS_D3D12"
 	TARGET_NAME                 = TARGET_NAME .. "_d3d12"
+	SOLUTION_NAME				= SOLUTION_NAME .. "_d3d12"
+	RUNTIME_NAME             	= RUNTIME_NAME .. "_d3d12"
 	IGNORE_FILES[0]             = RUNTIME_DIR .. "/RHI/D3D11/**"
 	IGNORE_FILES[1]             = RUNTIME_DIR .. "/RHI/Vulkan/**"
 elseif API_GRAPHICS == "vulkan" then
 	API_GRAPHICS                = "API_GRAPHICS_VULKAN"
 	TARGET_NAME                 = TARGET_NAME .. "_vulkan"
+	SOLUTION_NAME				= SOLUTION_NAME .. "_vulkan"
+	RUNTIME_NAME             	= RUNTIME_NAME .. "_vulkan"
 	IGNORE_FILES[0]             = RUNTIME_DIR .. "/RHI/D3D11/**"
 	IGNORE_FILES[1]             = RUNTIME_DIR .. "/RHI/D3D12/**"
 	ADDITIONAL_INCLUDES[0]      = "../ThirdParty/SPIRV-Cross-2021-01-15";


### PR DESCRIPTION
Create a different solution for each graphics API allowing developers to work on different graphics api without having to duplicate the project for each API.

 * Modified clean.sh, premake.lua.
 * A different visual studio solution and runtime project file will be created and postfixed with "_[graphics]".
 * A single editor project will remain.