### PR TITLE
Fixed New World and Camera Removal when there is a Light source.

### DIFF
--- a/Runtime/Rendering/Renderer_Passes.cpp
+++ b/Runtime/Rendering/Renderer_Passes.cpp
@@ -1731,7 +1731,7 @@ namespace Spartan
     void Renderer::Pass_AMD_FidelityFX_SinglePassDownsampler(RHI_CommandList* cmd_list, RHI_Texture* tex, const bool luminance_antiflicker)
     {
         // AMD FidelityFX Single Pass Downsampler.
-        // Provides an RDNA™-optimized solution for generating up to 12 MIP levels of a texture.
+        // Provides an RDNAâ„¢-optimized solution for generating up to 12 MIP levels of a texture.
         // GitHub:        https://github.com/GPUOpen-Effects/FidelityFX-SPD
         // Documentation: https://github.com/GPUOpen-Effects/FidelityFX-SPD/blob/master/docs/FidelityFX_SPD.pdf
 
@@ -1971,56 +1971,59 @@ namespace Spartan
         {
             if (cmd_list->BeginRenderPass(pso))
             {
-                // Light can be null if it just got removed and our buffer doesn't update till the next frame
-                if (Light* light = entity->GetComponent<Light>())
+                if (m_camera)
                 {
-                    Vector3 position_light_world      = entity->GetTransform()->GetPosition();
-                    Vector3 position_camera_world     = m_camera->GetTransform()->GetPosition();
-                    Vector3 direction_camera_to_light = (position_light_world - position_camera_world).Normalized();
-                    const float v_dot_l               = Vector3::Dot(m_camera->GetTransform()->GetForward(), direction_camera_to_light);
-
-                    // Only draw if it's inside our view
-                    if (v_dot_l > 0.5f)
+                    // Light can be null if it just got removed and our buffer doesn't update till the next frame
+                    if (Light* light = entity->GetComponent<Light>())
                     {
-                        // Compute light screen space position and scale (based on distance from the camera)
-                        const Vector2 position_light_screen = m_camera->WorldToScreenCoordinates(position_light_world);
-                        const float distance                = (position_camera_world - position_light_world).Length() + Helper::EPSILON;
-                        float scale                         = m_gizmo_size_max / distance;
-                        scale                               = Helper::Clamp(scale, m_gizmo_size_min, m_gizmo_size_max);
+                        Vector3 position_light_world      = entity->GetTransform()->GetPosition();
+                        Vector3 position_camera_world     = m_camera->GetTransform()->GetPosition();
+                        Vector3 direction_camera_to_light = (position_light_world - position_camera_world).Normalized();
+                        const float v_dot_l               = Vector3::Dot(m_camera->GetTransform()->GetForward(), direction_camera_to_light);
 
-                        // Choose texture based on light type
-                        shared_ptr<RHI_Texture> light_tex = nullptr;
-                        const LightType type = light->GetLightType();
-                        if (type == LightType::Directional) light_tex = m_tex_gizmo_light_directional;
-                        else if (type == LightType::Point)  light_tex = m_tex_gizmo_light_point;
-                        else if (type == LightType::Spot)   light_tex = m_tex_gizmo_light_spot;
-
-                        // Construct appropriate rectangle
-                        const float tex_width = light_tex->GetWidth() * scale;
-                        const float tex_height = light_tex->GetHeight() * scale;
-                        Math::Rectangle rectangle = Math::Rectangle
-                        (
-                            position_light_screen.x - tex_width * 0.5f,
-                            position_light_screen.y - tex_height * 0.5f,
-                            position_light_screen.x + tex_width,
-                            position_light_screen.y + tex_height
-                        );
-
-                        if (rectangle != m_gizmo_light_rect)
+                        // Only draw if it's inside our view
+                        if (v_dot_l > 0.5f)
                         {
-                            m_gizmo_light_rect = rectangle;
-                            m_gizmo_light_rect.CreateBuffers(this);
+                            // Compute light screen space position and scale (based on distance from the camera)
+                            const Vector2 position_light_screen = m_camera->WorldToScreenCoordinates(position_light_world);
+                            const float distance                = (position_camera_world - position_light_world).Length() + Helper::EPSILON;
+                            float scale                         = m_gizmo_size_max / distance;
+                            scale                               = Helper::Clamp(scale, m_gizmo_size_min, m_gizmo_size_max);
+
+                            // Choose texture based on light type
+                            shared_ptr<RHI_Texture> light_tex = nullptr;
+                            const LightType type = light->GetLightType();
+                            if (type == LightType::Directional) light_tex = m_tex_gizmo_light_directional;
+                            else if (type == LightType::Point)  light_tex = m_tex_gizmo_light_point;
+                            else if (type == LightType::Spot)   light_tex = m_tex_gizmo_light_spot;
+
+                            // Construct appropriate rectangle
+                            const float tex_width = light_tex->GetWidth() * scale;
+                            const float tex_height = light_tex->GetHeight() * scale;
+                            Math::Rectangle rectangle = Math::Rectangle
+                            (
+                                position_light_screen.x - tex_width * 0.5f,
+                                position_light_screen.y - tex_height * 0.5f,
+                                position_light_screen.x + tex_width,
+                                position_light_screen.y + tex_height
+                            );
+
+                            if (rectangle != m_gizmo_light_rect)
+                            {
+                                m_gizmo_light_rect = rectangle;
+                                m_gizmo_light_rect.CreateBuffers(this);
+                            }
+
+                            // Update uber buffer
+                            m_cb_uber_cpu.resolution_rt = Vector2(static_cast<float>(tex_width), static_cast<float>(tex_width));
+                            m_cb_uber_cpu.transform     = m_cb_frame_cpu.view_projection_ortho;
+                            Update_Cb_Uber(cmd_list);
+
+                            cmd_list->SetTexture(Renderer::Bindings_Srv::tex, light_tex);
+                            cmd_list->SetBufferIndex(m_gizmo_light_rect.GetIndexBuffer());
+                            cmd_list->SetBufferVertex(m_gizmo_light_rect.GetVertexBuffer());
+                            cmd_list->DrawIndexed(Rectangle::GetIndexCount());
                         }
-
-                        // Update uber buffer
-                        m_cb_uber_cpu.resolution_rt = Vector2(static_cast<float>(tex_width), static_cast<float>(tex_width));
-                        m_cb_uber_cpu.transform     = m_cb_frame_cpu.view_projection_ortho;
-                        Update_Cb_Uber(cmd_list);
-
-                        cmd_list->SetTexture(Renderer::Bindings_Srv::tex, light_tex);
-                        cmd_list->SetBufferIndex(m_gizmo_light_rect.GetIndexBuffer());
-                        cmd_list->SetBufferVertex(m_gizmo_light_rect.GetVertexBuffer());
-                        cmd_list->DrawIndexed(Rectangle::GetIndexCount());
                     }
                 }
                 cmd_list->EndRenderPass();

--- a/Runtime/World/World.cpp
+++ b/Runtime/World/World.cpp
@@ -62,9 +62,7 @@ namespace Spartan
         m_input    = m_context->GetSubsystem<Input>();
         m_profiler = m_context->GetSubsystem<Profiler>();
 
-        CreateCamera();
-        CreateEnvironment();
-        CreateDirectionalLight();
+        CreateDefaultWorldEntities();
 
         return true;
     }
@@ -155,6 +153,7 @@ namespace Spartan
     void World::New()
     {
         Clear();
+        CreateDefaultWorldEntities();
     }
 
     bool World::SaveToFile(const string& filePathIn)
@@ -399,6 +398,13 @@ namespace Spartan
         {
             parent->AcquireChildren();
         }
+    }
+
+    void World::CreateDefaultWorldEntities()
+    {
+        CreateCamera();
+        CreateEnvironment();
+        CreateDirectionalLight();
     }
 
     shared_ptr<Entity> World::CreateEnvironment()

--- a/Runtime/World/World.h
+++ b/Runtime/World/World.h
@@ -76,7 +76,8 @@ namespace Spartan
     private:
         void Clear();
         void _EntityRemove(const std::shared_ptr<Entity>& entity);
-
+        void CreateDefaultWorldEntities();
+        
         //= COMMON ENTITY CREATION ======================
         std::shared_ptr<Entity> CreateEnvironment();
         std::shared_ptr<Entity> CreateCamera();


### PR DESCRIPTION
Resolves #59 

- Fixed Crash when removing a camera and there is a light source.
- Create Default entities when creating a new World.

https://user-images.githubusercontent.com/12410116/168483270-2da93783-2ca2-4c5f-86ae-0f5766ec25a5.mp4

