### PR TITLE
[WIP] Camera Bookmarks

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -36,6 +36,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "Widgets/MenuBar.h"
 #include "Widgets/ProgressDialog.h"
 #include "Widgets/Properties.h"
+#include "Widgets/CameraBookmarkViewer.h"
 #include "Widgets/Viewport.h"
 #include "Widgets/WorldViewer.h"
 #include "Widgets/ShaderEditor.h"
@@ -304,6 +305,7 @@ void Editor::Initialise()
     m_widgets.emplace_back(make_shared<Viewport>(this));
     m_widgets.emplace_back(make_shared<AssetViewer>(this));
     m_widgets.emplace_back(make_shared<Properties>(this));
+    m_widgets.emplace_back(make_shared<CameraBookmarkViewer>(this));
     m_widgets.emplace_back(make_shared<WorldViewer>(this)); _editor::widget_world = m_widgets.back().get();
     m_widgets.emplace_back(make_shared<ProgressDialog>(this));
 }

--- a/Editor/Widgets/CameraBookmarkViewer.cpp
+++ b/Editor/Widgets/CameraBookmarkViewer.cpp
@@ -1,0 +1,143 @@
+#include "CameraBookmarkViewer.h"
+#include "../ImGuiExtension.h"
+#include "../ImGui/Source/imgui_stdlib.h"
+#include "../ImGui/Source/imgui_internal.h"
+#include "Core/Context.h"
+#include "Core/Engine.h"
+#include "World/Entity.h"
+#include "World/Components/Transform.h"
+
+//===============================================
+
+//= NAMESPACES =========
+using namespace std;
+using namespace Spartan;
+using namespace Math;
+//======================
+
+CameraBookmarkViewer::CameraBookmarkViewer(Editor* editor) : Widget(editor)
+{
+    m_title        = "Camera Bookmark Viewer";
+    m_size_initial = 500;
+}
+
+void CameraBookmarkViewer::TickVisible()
+{
+    ShowBookmarks();
+}
+
+void CameraBookmarkViewer::ShowBookmarks()
+{
+    const bool is_playing = m_context->m_engine->EngineMode_IsSet(Engine_Game);
+    if (is_playing)
+    {
+        return;
+    }
+
+    enum class Axis
+    {
+        x,
+        y,
+        z
+    };
+
+    const auto show_float = [](Axis axis, float* value)
+    {
+        const float label_float_spacing = 15.0f;
+        const float step = 0.01f;
+        const string format = "%.4f";
+
+        // Label
+        ImGui::TextUnformatted(axis == Axis::x ? "x" : axis == Axis::y ? "y" : "z");
+        ImGui::SameLine(label_float_spacing);
+        Vector2 pos_post_label = ImGui::GetCursorScreenPos();
+
+        // Float
+        ImGui::PushItemWidth(128.0f);
+        ImGui::PushID(static_cast<int>(ImGui::GetCursorPosX() + ImGui::GetCursorPosY()));
+        ImGuiEx::DragFloatWrap("##no_label", value, step, numeric_limits<float>::lowest(), numeric_limits<float>::max(), format.c_str());
+        ImGui::PopID();
+        ImGui::PopItemWidth();
+
+        // Axis color
+        static const ImU32 color_x = IM_COL32(168, 46, 2, 255);
+        static const ImU32 color_y = IM_COL32(112, 162, 22, 255);
+        static const ImU32 color_z = IM_COL32(51, 122, 210, 255);
+        static const Vector2 size = Vector2(4.0f, 19.0f);
+        static const Vector2 offset = Vector2(5.0f, 4.0);
+        pos_post_label += offset;
+        ImRect axis_color_rect = ImRect(pos_post_label.x, pos_post_label.y, pos_post_label.x + size.x, pos_post_label.y + size.y);
+        ImGui::GetWindowDrawList()->AddRectFilled(axis_color_rect.Min, axis_color_rect.Max, axis == Axis::x ? color_x : axis == Axis::y ? color_y : color_z);
+    };
+
+    const auto show_vector = [&show_float](const char* label, Vector3& vector)
+    {
+        const float label_indetation = 15.0f;
+
+        ImGui::BeginGroup();
+        ImGui::Indent(label_indetation);
+        ImGui::TextUnformatted(label);
+        ImGui::Unindent(label_indetation);
+        show_float(Axis::x, &vector.x);
+        show_float(Axis::y, &vector.y);
+        show_float(Axis::z, &vector.z);
+        ImGui::EndGroup();
+    };
+    const std::vector<CameraBookmark>& cameraBookmarks = m_context->GetSubsystem<World>()->GetCameraBookmarks();
+    for (int i = 0; i < cameraBookmarks.size(); ++i)
+    {
+        Vector3 position = cameraBookmarks[i].position;
+        Vector3 rotation = cameraBookmarks[i].rotation;
+
+        show_vector("Position", position);
+        ImGui::SameLine();
+        show_vector("Rotation", rotation);
+        ImGui::SameLine();
+        ShowGoToBookmarkButton(i);
+    }
+
+    ShowAddBookmarkButton();
+}
+
+void CameraBookmarkViewer::ShowAddBookmarkButton()
+{
+    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5);
+    ImGui::SetCursorPosX(ImGui::GetWindowWidth() * 0.5f - 50);
+    if (ImGuiEx::Button("Add Bookmark"))
+    {
+        if (auto camera = m_context->GetSubsystem<World>()->EntityGetByName("Camera"))
+        {
+            auto transform = camera->GetComponent<Transform>();
+            AddCameraBookmark({transform->GetPosition(), transform->GetRotation().ToEulerAngles()});
+        }
+    }
+}
+
+void CameraBookmarkViewer::ShowGoToBookmarkButton(int bookmarkIndex)
+{
+    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 50);
+    ImGui::SetCursorPosX(ImGui::GetWindowWidth() * 0.5f - 5);
+
+    //Not the best allocation friendly. Find a way to refer buttons other than names.
+    std::string buttonLabel = "Go To Bookmark " + to_string(bookmarkIndex);
+    if (ImGuiEx::Button(buttonLabel.c_str()))
+    {
+        GoToBookmark(bookmarkIndex);
+    }
+}
+
+void CameraBookmarkViewer::GoToBookmark(int bookmarkIndex)
+{
+    if (auto camera = m_context->GetSubsystem<World>()->EntityGetByName("Camera"))
+    {
+        const std::vector<CameraBookmark>& cameraBookmarks = m_context->GetSubsystem<World>()->GetCameraBookmarks();
+        LOG_INFO("CameraBookmark: Position = %s, Rotation = %s", cameraBookmarks[bookmarkIndex].position.ToString().c_str(), cameraBookmarks[bookmarkIndex].rotation.ToString().c_str());
+        auto cameraComponent = camera->GetComponent<Camera>();
+        cameraComponent->GoToCameraBookmark(bookmarkIndex);
+    }
+}
+
+void CameraBookmarkViewer::AddCameraBookmark(CameraBookmark bookmark)
+{
+    m_context->GetSubsystem<World>()->AddCameraBookmark(bookmark);
+}

--- a/Editor/Widgets/CameraBookmarkViewer.h
+++ b/Editor/Widgets/CameraBookmarkViewer.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "Widget.h"
+#include "World/World.h"
+#include "Math/Vector3.h"
+
+class CameraBookmarkViewer : public Widget
+{
+public:
+    CameraBookmarkViewer(Editor* editor);
+    void TickVisible() override;
+
+private:
+    void ShowBookmarks();
+    void ShowAddBookmarkButton();
+    void AddCameraBookmark(Spartan::CameraBookmark bookmark);
+
+    void ShowGoToBookmarkButton(int bookmarkIndex);
+    void GoToBookmark(int bookmarkIndex);
+};

--- a/Runtime/World/Components/Camera.cpp
+++ b/Runtime/World/Components/Camera.cpp
@@ -480,8 +480,22 @@ namespace Spartan
             }
         }
 
+        bool lerpToCameraBookmark = false;
+        if (const std::vector<CameraBookmark>& cameraBookmarks = m_context->GetSubsystem<World>()->GetCameraBookmarks();
+            lerpToCameraBookmark = m_lerpt_to_bookmark && m_targetBookmark_index >= 0 && m_targetBookmark_index < cameraBookmarks.size())
+        {
+            m_lerp_to_target_position = cameraBookmarks[m_targetBookmark_index].position;
+
+            // Compute lerp speed based on how far the entity is from the camera.
+            m_lerp_to_target_speed    = Vector3::Distance(m_lerp_to_target_position, m_transform->GetPosition()) * 0.1f;
+            m_lerp_to_target          = true;
+
+            m_targetBookmark_index     = -1;
+            m_lerpt_to_bookmark        = false;
+        }
+
         // Lerp
-        if (m_lerp_to_target)
+        if (m_lerp_to_target || lerpToCameraBookmark)
         {
             // Alpha
             m_lerp_to_target_alpha += m_lerp_to_target_speed * static_cast<float>(delta_time);
@@ -540,5 +554,14 @@ namespace Spartan
         }
 
         return Matrix::Identity;
+    }
+
+    void Spartan::Camera::GoToCameraBookmark(int bookmarkIndex)
+    {
+        if (bookmarkIndex >= 0)
+        {
+            m_targetBookmark_index = bookmarkIndex;
+            m_lerpt_to_bookmark    = true;
+        }
     }
 }

--- a/Runtime/World/Components/Camera.h
+++ b/Runtime/World/Components/Camera.h
@@ -129,6 +129,8 @@ namespace Spartan
         Math::Matrix ComputeViewMatrix() const;
         Math::Matrix ComputeProjection(const bool reverse_z, const float near_plane = 0.0f, const float far_plane = 0.0f);
 
+        void GoToCameraBookmark(int bookmarkIndex);
+
     private:
         void ProcessInput(double delta_time);
         void ProcessInputFpsControl(double delta_time);
@@ -162,6 +164,8 @@ namespace Spartan
         float m_mouse_sensitivity               = 0.2f;
         float m_mouse_smoothing                 = 0.5f;
         bool m_lerp_to_target                   = false;
+        bool m_lerpt_to_bookmark                = false;
+        int m_targetBookmark_index              = -1;
         float m_lerp_to_target_alpha            = 0.0f;
         float m_lerp_to_target_speed            = 0.0f;
         Math::Vector3 m_lerp_to_target_position = Math::Vector3::Zero;

--- a/Runtime/World/World.h
+++ b/Runtime/World/World.h
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <string>
 #include "../Core/Subsystem.h"
 #include "../Core/SpartanDefinitions.h"
+#include "../Math/Vector3.h"
 //=====================================
 
 namespace Spartan
@@ -38,6 +39,12 @@ namespace Spartan
     class Profiler;
     class TransformHandle;
     //====================
+
+    struct CameraBookmark
+    {
+        Spartan::Math::Vector3 position = Spartan::Math::Vector3::Zero;
+        Spartan::Math::Vector3 rotation = Spartan::Math::Vector3::Zero;
+    };
 
     class SPARTAN_CLASS World : public Subsystem
     {
@@ -69,6 +76,11 @@ namespace Spartan
         const auto& EntityGetAll() const { return m_entities; }
         //======================================================================
 
+        //= CAMERA BOOKMARKS ============================
+        inline void AddCameraBookmark(CameraBookmark bookmark) { m_cameraBookmarks.emplace_back(bookmark); };
+        inline const std::vector<CameraBookmark>& GetCameraBookmarks() const { return m_cameraBookmarks; };
+        //===============================================
+
         // Transform handle
         std::shared_ptr<TransformHandle> GetTransformHandle() { return m_transform_handle; }
         float m_gizmo_transform_size  = 0.015f;
@@ -76,9 +88,9 @@ namespace Spartan
     private:
         void Clear();
         void _EntityRemove(const std::shared_ptr<Entity>& entity);
-        void CreateDefaultWorldEntities();
-        
+
         //= COMMON ENTITY CREATION ======================
+        void CreateDefaultWorldEntities();
         std::shared_ptr<Entity> CreateEnvironment();
         std::shared_ptr<Entity> CreateCamera();
         std::shared_ptr<Entity> CreateDirectionalLight();
@@ -93,5 +105,6 @@ namespace Spartan
 
         std::shared_ptr<TransformHandle> m_transform_handle;
         std::vector<std::shared_ptr<Entity>> m_entities;
+        std::vector<CameraBookmark> m_cameraBookmarks;
     };
 }


### PR DESCRIPTION
# Camera Bookmarks
This is a simple proof of concept for Camera Bookmarks.
Camera Bookmarks allows the user to easily navigate the world by allowing to save camera positions and then lerp between them as desired. 

- When the "Add Bookmark" button is pressed the system stores the current position and rotation of the camera.
- When the "Go To Bookmark" button is pressed the system lerps the camera to the corresponding bookmark position.

https://user-images.githubusercontent.com/12410116/168583493-749db07e-6ebe-41f0-b06b-c4a66ddd79be.mp4

## Things to consider about the feature:
- Currently the bookmarks are being loaded and unloaded at runtime, might be worth considering serialize them into a separate file for each world (or inside the .world file) in order to make them persist between sessions and having a different set of bookmarks for each World.

- Currently The bookmarks are being saved in the "World" subsystem, it might be worth create a different subsystem for this task.

- Add more properties to bookmarks (near plane, far plane, frustum, ...)

- The UI is very much an early WIP don't consider it too much :P 

## General Observations
- Might be worth to abstract the imgui vector display in order to easily create a vector frontend that can be easily inserted in other places in the engine.

![image](https://user-images.githubusercontent.com/12410116/168585778-e3472d56-efd9-488d-a9ee-61f60b9aead8.png)
