### PR TITLE
Removed compiler specific directives

### DIFF
--- a/Runtime/Core/SpartanDefinitions.h
+++ b/Runtime/Core/SpartanDefinitions.h
@@ -1,28 +1,56 @@
 #pragma once
 
+// TODO: see a way to add #pragma GCC diagnostic push/pop with macros (maybe something like _Pragma)
+
 // Version
 #define sp_version "v0.33"
 
-// Class
-#define SPARTAN_CLASS
-#if SPARTAN_RUNTIME_SHARED == 1
-#ifdef SPARTAN_RUNTIME
-#define SPARTAN_CLASS __declspec(dllexport)
+#if defined(__GNUC__)
+    // Class
+    #define SPARTAN_CLASS
+    #if SPARTAN_RUNTIME_SHARED == 1
+        #ifdef SPARTAN_RUNTIME
+            #define SPARTAN_CLASS __attribute__((visibility("default")))
+        #else
+            #define SPARTAN_CLASS 
+        #endif
+    #endif
+
+    // Optimisation
+    #define SP_OPTIMISE_OFF
+    #define SP_OPTIMISE_ON
+
+    // Warnings
+    #define SP_WARNINGS_OFF
+    #define SP_WARNINGS_ON
+
+    // Debug break
+    #define SP_DEBUG_BREAK() abort()
+#elif defined(_MSC_VER)
+    // Class
+    #define SPARTAN_CLASS
+    #if SPARTAN_RUNTIME_SHARED == 1
+        #ifdef SPARTAN_RUNTIME
+            #define SPARTAN_CLASS __declspec(dllexport)
+        #else
+            #define SPARTAN_CLASS __declspec(dllimport)
+        #endif
+    #endif
+
+    // Optimisation
+    #define SP_OPTIMISE_OFF __pragma(optimize("", off))
+    #define SP_OPTIMISE_ON __pragma(optimize("", on))
+
+    // Warnings
+    #define SP_WARNINGS_OFF __pragma(warning(push, 0))
+    #define SP_WARNINGS_ON __pragma(warning(pop))
+
+    // Debug break
+    #define SP_DEBUG_BREAK() __debugbreak()
 #else
-#define SPARTAN_CLASS __declspec(dllimport)
+    #pragma warn "Unkown compiler/platform."
 #endif
-#endif
 
-// Optimisation
-#define SP_OPTIMISE_OFF __pragma(optimize("", off))
-#define SP_OPTIMISE_ON __pragma(optimize("", on))
-
-// Warnings
-#define SP_WARNINGS_OFF __pragma(warning(push, 0))
-#define SP_WARNINGS_ON __pragma(warning(pop))
-
-// Debug break
-#define SP_DEBUG_BREAK() __debugbreak()
 
 //= Assert ==========================================================================
 // On debug mode, the assert will have the default behaviour.
@@ -62,7 +90,7 @@ if (x)               \
 //= DISABLED WARNINGS ==============================================================================================================================
 // identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
 #pragma warning(disable: 4251) // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=vs-2019
-// non – DLL-interface classkey 'identifier' used as base for DLL-interface classkey 'identifier'
+// non ï¿½ DLL-interface classkey 'identifier' used as base for DLL-interface classkey 'identifier'
 #pragma warning(disable: 4275) // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=vs-2019
 // no definition for inline function 'function'
 #pragma warning(disable: 4506) // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4506?view=vs-2017

--- a/Runtime/Core/SpartanDefinitions.h
+++ b/Runtime/Core/SpartanDefinitions.h
@@ -87,6 +87,7 @@ if (x)               \
 #define NOMINMAX
 #endif
 
+#ifdef _MSC_VER
 //= DISABLED WARNINGS ==============================================================================================================================
 // identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
 #pragma warning(disable: 4251) // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=vs-2019
@@ -95,3 +96,4 @@ if (x)               \
 // no definition for inline function 'function'
 #pragma warning(disable: 4506) // https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4506?view=vs-2017
 //==================================================================================================================================================
+#endif

--- a/Runtime/Core/SpartanDefinitions.h
+++ b/Runtime/Core/SpartanDefinitions.h
@@ -17,12 +17,13 @@
     #endif
 
     // Optimisation
-    #define SP_OPTIMISE_OFF
-    #define SP_OPTIMISE_ON
+    #define SP_OPTIMISE_OFF _Pragma("GCC optimize(\"O2\"")
+    #define SP_OPTIMISE_ON _Pragma("GCC optimize(\"O0\"")
 
     // Warnings
-    #define SP_WARNINGS_OFF
-    #define SP_WARNINGS_ON
+    #define SP_WARNINGS_OFF _Pragma("GCC diagnostic push") \
+                            _Pragma("GCC diagnostic ignored \"-Wall -Wpedantic\"")
+    #define SP_WARNINGS_ON _Pragma("GCC diagnostic pop")
 
     // Debug break
     #define SP_DEBUG_BREAK() abort()

--- a/Runtime/Core/SpartanDefinitions.h
+++ b/Runtime/Core/SpartanDefinitions.h
@@ -5,7 +5,27 @@
 // Version
 #define sp_version "v0.33"
 
-#if defined(__GNUC__)
+#if defined(__clang__)
+    #pragma warn "SP_OPTIMISE and SP_WARNINGS are not implemented for clang"
+    
+    // Class
+    #define SPARTAN_CLASS
+    #if SPARTAN_RUNTIME_SHARED == 1
+        #ifdef SPARTAN_RUNTIME
+            #define SPARTAN_CLASS __attribute__((visibility("default")))
+        #else
+            #define SPARTAN_CLASS 
+        #endif
+    #endif
+
+    // Optimisation
+    #define SP_OPTIMISE_OFF
+    #define SP_OPTIMISE_ON 
+
+    // Warnings
+    #define SP_WARNINGS_OFF 
+    #define SP_WARNINGS_ON
+#elif defined(__GNUC__) || defined(__GNUG__)
 
     #include <signal.h>
 

--- a/Runtime/Core/SpartanDefinitions.h
+++ b/Runtime/Core/SpartanDefinitions.h
@@ -19,12 +19,13 @@
     #endif
 
     // Optimisation
-    #define SP_OPTIMISE_OFF
-    #define SP_OPTIMISE_ON 
+    #define SP_OPTIMISE_OFF _Pragma("clang optimize off")
+    #define SP_OPTIMISE_ON _Pragma("clang optimize on")
 
     // Warnings
-    #define SP_WARNINGS_OFF 
-    #define SP_WARNINGS_ON
+    #define SP_WARNINGS_OFF _Pragma("clang diagnostic push") \
+                            _Pragma("clang diagnostic ignored \"-Wall -Wpedantic\"")
+    #define SP_WARNINGS_ON _Pragma("clang diagnostic pop")
 #elif defined(__GNUC__) || defined(__GNUG__)
 
     #include <signal.h>

--- a/Runtime/Core/SpartanDefinitions.h
+++ b/Runtime/Core/SpartanDefinitions.h
@@ -6,6 +6,9 @@
 #define sp_version "v0.33"
 
 #if defined(__GNUC__)
+
+    #include <signal.h>
+
     // Class
     #define SPARTAN_CLASS
     #if SPARTAN_RUNTIME_SHARED == 1
@@ -26,7 +29,7 @@
     #define SP_WARNINGS_ON _Pragma("GCC diagnostic pop")
 
     // Debug break
-    #define SP_DEBUG_BREAK() abort()
+    #define SP_DEBUG_BREAK() raise(SIGTRAP)
 #elif defined(_MSC_VER)
     // Class
     #define SPARTAN_CLASS

--- a/Runtime/Core/SpartanDefinitions.h
+++ b/Runtime/Core/SpartanDefinitions.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// TODO: see a way to add #pragma GCC diagnostic push/pop with macros (maybe something like _Pragma)
+// TODO: detect clang and add clang specific directives
 
 // Version
 #define sp_version "v0.33"


### PR DESCRIPTION
PR to get closer to a working linux port (issue #66)

Removed compiler specific directives like `__debugbreak()` and `__declspec` in order to be more portable. Other systems like GNU/Linux don't support those intrinsics, so they need to be replaced.

Checking if `__GNUC__` is defined we can detect if gcc is being used

Status of PR:

- [x] Replace `__declspec` with GNU/Linux directives.
- [x] Replace `__pragma(optimize)` with GNU/Linux directives 
- [x] Replace `__pragma(warning)` with GNU/Linux directives 
- [x] Detect clang compiler usage (and use clang specific directives)

GCC and CLANG seem to work differently as to what MSVC does, as they mostly work by pushing the current state, changing the state for a brief period, and then changing it back to what it was. This should not be a problem as I've seen the pattern `DISABLE_WHATEVER` do things `ENABLE_WHATEVER` in the engine, but is something to think about in the future.