### PR TITLE
Removing Windows.h

### DIFF
--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -24,7 +24,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <Windows.h>
 //==================
 
+#ifdef _WIN32
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
+#else
 int main(int argc, char** argv)
+#endif
 {
     Editor editor;
     editor.Tick();

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -24,7 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <Windows.h>
 //==================
 
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
+int main(int argc, char** argv)
 {
     Editor editor;
     editor.Tick();

--- a/Runtime/Display/Display.cpp
+++ b/Runtime/Display/Display.cpp
@@ -79,34 +79,73 @@ namespace Spartan
 
     uint32_t Display::GetWidth()
     {
+        // Initialise video subsystem (if needed)
+        if (SDL_WasInit(SDL_INIT_VIDEO) != 1)
+        {
+            if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0)
+            {
+                LOG_ERROR("Failed to initialise SDL video subsystem: %s.", SDL_GetError());
+                return 0;
+            }
+        }
+        
         // FIXME: SDL aparently only shows virtual metrics.
         SDL_DisplayMode dm;
-        SP_ASSERT(SDL_GetDesktopDisplayMode(0, &dm) == 0);
+        SP_ASSERT(SDL_GetCurrentDisplayMode(0, &dm) == 0);
 
         return dm.w;
     }
 
     uint32_t Display::GetHeight()
     {
+        // Initialise video subsystem (if needed)
+        if (SDL_WasInit(SDL_INIT_VIDEO) != 1)
+        {
+            if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0)
+            {
+                LOG_ERROR("Failed to initialise SDL video subsystem: %s.", SDL_GetError());
+                return 0;
+            }
+        }
+        
         // FIXME: SDL aparently only shows virtual metrics.
         SDL_DisplayMode dm;
-        SP_ASSERT(SDL_GetDesktopDisplayMode(0, &dm) == 0);
+        SP_ASSERT(SDL_GetCurrentDisplayMode(0, &dm) == 0);
 
         return dm.h;
     }
 
     uint32_t Display::GetWidthVirtual()
     {
+        // Initialise video subsystem (if needed)
+        if (SDL_WasInit(SDL_INIT_VIDEO) != 1)
+        {
+            if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0)
+            {
+                LOG_ERROR("Failed to initialise SDL video subsystem: %s.", SDL_GetError());
+                return 0;
+            }
+        }
         SDL_DisplayMode dm;
-        SP_ASSERT(SDL_GetDesktopDisplayMode(0, &dm) == 0);
+        SP_ASSERT(SDL_GetCurrentDisplayMode(0, &dm) == 0);
 
         return dm.w;
     }
 
     uint32_t Display::GetHeightVirtual()
     {
+        // Initialise video subsystem (if needed)
+        if (SDL_WasInit(SDL_INIT_VIDEO) != 1)
+        {
+            if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0)
+            {
+                LOG_ERROR("Failed to initialise SDL video subsystem: %s.", SDL_GetError());
+                return 0;
+            }
+        }
+
         SDL_DisplayMode dm;
-        SP_ASSERT(SDL_GetDesktopDisplayMode(0, &dm) == 0);
+        SP_ASSERT(SDL_GetCurrentDisplayMode(0, &dm) == 0);
 
         return dm.h;
     }

--- a/Runtime/Display/Display.cpp
+++ b/Runtime/Display/Display.cpp
@@ -22,7 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //= INCLUDES =======
 #include "Spartan.h"
 #include "Display.h"
-#include <windows.h>
+#include "SDL.h"
 //==================
 
 namespace Spartan
@@ -79,21 +79,35 @@ namespace Spartan
 
     uint32_t Display::GetWidth()
     {
-        return static_cast<uint32_t>(GetSystemMetrics(SM_CXSCREEN));
+        // FIXME: SDL aparently only shows virtual metrics.
+        SDL_DisplayMode dm;
+        SP_ASSERT(SDL_GetDesktopDisplayMode(0, &dm) == 0);
+
+        return dm.w;
     }
 
     uint32_t Display::GetHeight()
     {
-        return static_cast<uint32_t>(GetSystemMetrics(SM_CYSCREEN));
+        // FIXME: SDL aparently only shows virtual metrics.
+        SDL_DisplayMode dm;
+        SP_ASSERT(SDL_GetDesktopDisplayMode(0, &dm) == 0);
+
+        return dm.h;
     }
 
     uint32_t Display::GetWidthVirtual()
     {
-        return static_cast<uint32_t>(GetSystemMetrics(SM_CXVIRTUALSCREEN));
+        SDL_DisplayMode dm;
+        SP_ASSERT(SDL_GetDesktopDisplayMode(0, &dm) == 0);
+
+        return dm.w;
     }
 
     uint32_t Display::GetHeightVirtual()
     {
-        return static_cast<uint32_t>(GetSystemMetrics(SM_CYVIRTUALSCREEN));
+        SDL_DisplayMode dm;
+        SP_ASSERT(SDL_GetDesktopDisplayMode(0, &dm) == 0);
+
+        return dm.h;
     }
 }


### PR DESCRIPTION
All instances of including `Windows.h` has been removed on non-windows systems.

Older MSVC versions let you use the traditional `main(int argc, char** argv)` signature, but newer versions dont. So to solve this `ifdef` has been used in order to use one or the other signature. 

Windows functions where used on the display module in order to get the display width and heigh. The windows specific functions has been replaced with SDL functions.

A small caveat: GetWidth and GetVirtualWidth return the same value as SDL does not separate Virtual and non Virtual resolutions. A small solution would be to use Windows functions on windows while using SDL as a fallback on non supported systems. As far as I know wayland (the windowing system used on some linux systems) does not allow applications to know display resolution as protection meassure, so that can be a bit of a pain.