### PR TITLE
Fix camera focus (F key) functionality

### DIFF
--- a/runtime/Math/Quaternion.cpp
+++ b/runtime/Math/Quaternion.cpp
@@ -42,9 +42,9 @@ namespace Spartan::Math
     void Quaternion::FromAxes(const Vector3& xAxis, const Vector3& yAxis, const Vector3& zAxis)
     {
         *this = Matrix(
-            xAxis.x, yAxis.x, zAxis.x, 0.0f,
-            xAxis.y, yAxis.y, zAxis.y, 0.0f,
-            xAxis.z, yAxis.z, zAxis.z, 0.0f,
+            xAxis.x, xAxis.y, xAxis.z, 0.0f,
+            yAxis.x, yAxis.y, yAxis.z, 0.0f,
+            zAxis.x, zAxis.y, zAxis.z, 0.0f,
             0.0f, 0.0f, 0.0f, 1.0f
         ).GetRotation();
     }

--- a/runtime/World/Components/Camera.cpp
+++ b/runtime/World/Components/Camera.cpp
@@ -531,7 +531,7 @@ namespace Spartan
                     m_lerp_to_target_position -= target_direction;
                 }
 
-                m_lerp_to_target_rotation  = Quaternion::FromLookRotation(m_lerp_to_target_position - m_transform->GetPosition()).Normalized();
+                m_lerp_to_target_rotation  = Quaternion::FromLookRotation(entity->GetTransform()->GetPosition() - m_lerp_to_target_position).Normalized();
                 m_lerp_to_target_distance  = Vector3::Distance(m_lerp_to_target_position, m_transform->GetPosition());
 
                 const float lerp_angle = acosf(Quaternion::Dot(m_lerp_to_target_rotation.Normalized(), m_transform->GetRotation().Normalized())) * Helper::RAD_TO_DEG;

--- a/runtime/World/Components/Camera.cpp
+++ b/runtime/World/Components/Camera.cpp
@@ -517,20 +517,18 @@ namespace Spartan
             {
                 SP_LOG_INFO("Focusing on entity \"%s\"...", entity->GetTransform()->GetEntity()->GetName().c_str());
 
+                m_lerp_to_target_position       = entity->GetTransform()->GetPosition();
+                const Vector3 target_direction  = (m_lerp_to_target_position - m_transform->GetPosition()).Normalized();
+
                 // If the entity has a renderable component, we can get a more accurate target position.
-                // ...otherwise get the default transform position and apply an offset so that the rotation
-                // vector doesn't suffer
+                // ...otherwise we apply a simple offset so that the rotation vector doesn't suffer
                 if (Renderable* renderable = entity->GetRenderable())
                 {
-                    m_lerp_to_target_position       = entity->GetTransform()->GetPosition();
-                    const Vector3 target_direction  = (m_lerp_to_target_position - m_transform->GetPosition()).Normalized();
-                    m_lerp_to_target_position       -= target_direction * renderable->GetAabb().GetExtents().Length() * 2.0f;
+                    m_lerp_to_target_position -= target_direction * renderable->GetAabb().GetExtents().Length() * 2.0f;
                 }
                 else
                 {
-                    m_lerp_to_target_position       = entity->GetTransform()->GetPosition();
-                    const Vector3 target_direction  = (m_lerp_to_target_position - m_transform->GetPosition()).Normalized();
-                    m_lerp_to_target_position       -= target_direction;
+                    m_lerp_to_target_position -= target_direction;
                 }
 
                 m_lerp_to_target_rotation  = Quaternion::FromLookRotation(m_lerp_to_target_position - m_transform->GetPosition()).Normalized();

--- a/runtime/World/Components/Camera.cpp
+++ b/runtime/World/Components/Camera.cpp
@@ -42,7 +42,7 @@ using namespace std;
 namespace Spartan
 {
     Camera::Camera(Entity* entity, uint64_t id /*= 0*/) : IComponent(entity, id)
-    {   
+    {
 
     }
 
@@ -253,7 +253,7 @@ namespace Spartan
                 Vector3 p3_world = Vector3(vertices[indicies[i + 2]].pos) * vertex_transform;
 
                 float distance = m_ray.HitDistance(p1_world, p2_world, p3_world);
-                
+
                 if (distance < distance_min)
                 {
                     m_selected_entity = hit.m_entity;
@@ -517,21 +517,29 @@ namespace Spartan
             {
                 SP_LOG_INFO("Focusing on entity \"%s\"...", entity->GetTransform()->GetEntity()->GetName().c_str());
 
-                // Get lerp target position.
-                m_lerp_to_target_position = entity->GetTransform()->GetPosition();
-
                 // If the entity has a renderable component, we can get a more accurate target position.
+                // ...otherwise get the default transform position and apply an offset so that the rotation
+                // vector doesn't suffer
                 if (Renderable* renderable = entity->GetRenderable())
                 {
-                    m_lerp_to_target_position = renderable->GetAabb().GetCenter();
-
-                    Vector3 target_direction  = (m_lerp_to_target_position - m_transform->GetPosition()).Normalized();
-                    m_lerp_to_target_position -= target_direction * renderable->GetAabb().GetExtents().Length() * 2.0f;
+                    m_lerp_to_target_position       = entity->GetTransform()->GetPosition();
+                    const Vector3 target_direction  = (m_lerp_to_target_position - m_transform->GetPosition()).Normalized();
+                    m_lerp_to_target_position       -= target_direction * renderable->GetAabb().GetExtents().Length() * 2.0f;
+                }
+                else
+                {
+                    m_lerp_to_target_position       = entity->GetTransform()->GetPosition();
+                    const Vector3 target_direction  = (m_lerp_to_target_position - m_transform->GetPosition()).Normalized();
+                    m_lerp_to_target_position       -= target_direction;
                 }
 
-                // Compute lerp speed based on how far the entity is from the camera.
-                m_lerp_to_target_speed = Vector3::Distance(m_lerp_to_target_position, m_transform->GetPosition()) * 0.1f;
-                m_lerp_to_target       = true;
+                m_lerp_to_target_rotation  = Quaternion::FromLookRotation(m_lerp_to_target_position - m_transform->GetPosition()).Normalized();
+                m_lerp_to_target_distance  = Vector3::Distance(m_lerp_to_target_position, m_transform->GetPosition());
+
+                const float lerp_angle = acosf(Quaternion::Dot(m_lerp_to_target_rotation.Normalized(), m_transform->GetRotation().Normalized())) * Helper::RAD_TO_DEG;
+
+                m_lerp_to_target_p = m_lerp_to_target_distance > 0.1f ? true : false;
+                m_lerp_to_target_r = lerp_angle > 1.0f ? true : false;
             }
         }
 
@@ -542,32 +550,43 @@ namespace Spartan
             m_lerp_to_target_position = m_bookmarks[m_target_bookmark_index].position;
 
             // Compute lerp speed based on how far the entity is from the camera.
-            m_lerp_to_target_speed = Vector3::Distance(m_lerp_to_target_position, m_transform->GetPosition()) * 0.1f;
-            m_lerp_to_target       = true;
+            m_lerp_to_target_distance = Vector3::Distance(m_lerp_to_target_position, m_transform->GetPosition());
+            m_lerp_to_target_p       = true;
 
             m_target_bookmark_index = -1;
             m_lerpt_to_bookmark     = false;
         }
 
         // Lerp
-        if (m_lerp_to_target || lerp_to_bookmark)
+        if (m_lerp_to_target_p || m_lerp_to_target_r || lerp_to_bookmark)
         {
+            // Lerp duration in seconds
+            // 2.0 seconds + [0.0 - 2.0] seconds based on distance
+            // Something is not right with the duration...
+            const float lerp_duration = 2.0f + Helper::Clamp(m_lerp_to_target_distance * 0.01f, 0.0f, 2.0f);
+
             // Alpha
-            m_lerp_to_target_alpha += m_lerp_to_target_speed * static_cast<float>(Timer::GetDeltaTimeSec());
+            m_lerp_to_target_alpha += static_cast<float>(Timer::GetDeltaTimeSec()) / lerp_duration;
 
             // Position
-            Vector3 interpolated_position = Vector3::Lerp(m_transform->GetPosition(), m_lerp_to_target_position, m_lerp_to_target_alpha);
-            m_transform->SetPosition(interpolated_position);
+            if (m_lerp_to_target_p)
+            {
+                const Vector3 interpolated_position = Vector3::Lerp(m_transform->GetPosition(), m_lerp_to_target_position, m_lerp_to_target_alpha);
+                m_transform->SetPosition(interpolated_position);
+            }
 
             // Rotation
-            Vector3 target_direction         = (m_lerp_to_target_position - m_transform->GetPosition()).Normalized();
-            Quaternion interpolated_rotation = Quaternion::Lerp(m_transform->GetRotation(), Quaternion::FromLookRotation(target_direction), m_lerp_to_target_alpha);
-            //m_transform->SetRotation(interpolated_rotation);
+            if (m_lerp_to_target_r)
+            {
+                const Quaternion interpolated_rotation = Quaternion::Lerp(m_transform->GetRotation(), m_lerp_to_target_rotation, Helper::Clamp(m_lerp_to_target_alpha, 0.0f, 1.0f));
+                m_transform->SetRotation(interpolated_rotation);
+            }
 
             // If the lerp has completed or the user has initiated fps control, stop lerping.
             if (m_lerp_to_target_alpha >= 1.0f || m_is_controlled_by_keyboard_mouse)
             {
-                m_lerp_to_target          = false;
+                m_lerp_to_target_p        = false;
+                m_lerp_to_target_r        = false;
                 m_lerp_to_target_alpha    = 0.0f;
                 m_lerp_to_target_position = Vector3::Zero;
             }

--- a/runtime/World/Components/Camera.h
+++ b/runtime/World/Components/Camera.h
@@ -150,39 +150,41 @@ namespace Spartan
         void ProcessInputFpsControl();
         void ProcessInputLerpToEntity();
 
-        float m_aperture                        = 50.0f;        // Size of the lens diaphragm (mm). Controls depth of field and chromatic aberration.
-        float m_shutter_speed                   = 1.0f / 60.0f; // Length of time for which the camera shutter is open (sec). Also controls the amount of motion blur.
-        float m_iso                             = 500.0f;       // Sensitivity to light.
-        float m_fov_horizontal_rad              = Math::Helper::DegreesToRadians(90.0f);
-        float m_near_plane                      = 0.1f;
-        float m_far_plane                       = 1000.0f;
-        ProjectionType m_projection_type        = Projection_Perspective;
-        Color m_clear_color                     = Color::standard_cornflower_blue;
-        Math::Matrix m_view                     = Math::Matrix::Identity;
-        Math::Matrix m_projection               = Math::Matrix::Identity;
-        Math::Matrix m_view_projection          = Math::Matrix::Identity;
-        Math::Vector3 m_position                = Math::Vector3::Zero;
-        Math::Quaternion m_rotation             = Math::Quaternion::Identity;
-        bool m_is_dirty                         = false;
-        bool m_first_person_control_enabled     = true;
-        bool m_is_controlled_by_keyboard_mouse  = false;
-        Math::Vector2 m_mouse_last_position     = Math::Vector2::Zero;
-        bool m_fps_control_cursor_hidden        = false;
-        Math::Vector3 m_movement_speed          = Math::Vector3::Zero;
-        float m_movement_speed_min              = 0.5f;
-        float m_movement_speed_max              = 5.0f;
-        float m_movement_acceleration           = 1000.0f;
-        float m_movement_drag                   = 10.0f;
-        Math::Vector2 m_mouse_smoothed          = Math::Vector2::Zero;
-        Math::Vector2 m_first_person_rotation   = Math::Vector2::Zero;
-        float m_mouse_sensitivity               = 0.2f;
-        float m_mouse_smoothing                 = 0.5f;
-        bool m_lerp_to_target                   = false;
-        bool m_lerpt_to_bookmark                = false;
-        int m_target_bookmark_index             = -1;
-        float m_lerp_to_target_alpha            = 0.0f;
-        float m_lerp_to_target_speed            = 0.0f;
-        Math::Vector3 m_lerp_to_target_position = Math::Vector3::Zero;
+        float m_aperture                           = 50.0f;        // Size of the lens diaphragm (mm). Controls depth of field and chromatic aberration.
+        float m_shutter_speed                      = 1.0f / 60.0f; // Length of time for which the camera shutter is open (sec). Also controls the amount of motion blur.
+        float m_iso                                = 500.0f;       // Sensitivity to light.
+        float m_fov_horizontal_rad                 = Math::Helper::DegreesToRadians(90.0f);
+        float m_near_plane                         = 0.1f;
+        float m_far_plane                          = 1000.0f;
+        ProjectionType m_projection_type           = Projection_Perspective;
+        Color m_clear_color                        = Color::standard_cornflower_blue;
+        Math::Matrix m_view                        = Math::Matrix::Identity;
+        Math::Matrix m_projection                  = Math::Matrix::Identity;
+        Math::Matrix m_view_projection             = Math::Matrix::Identity;
+        Math::Vector3 m_position                   = Math::Vector3::Zero;
+        Math::Quaternion m_rotation                = Math::Quaternion::Identity;
+        bool m_is_dirty                            = false;
+        bool m_first_person_control_enabled        = true;
+        bool m_is_controlled_by_keyboard_mouse     = false;
+        Math::Vector2 m_mouse_last_position        = Math::Vector2::Zero;
+        bool m_fps_control_cursor_hidden           = false;
+        Math::Vector3 m_movement_speed             = Math::Vector3::Zero;
+        float m_movement_speed_min                 = 0.5f;
+        float m_movement_speed_max                 = 5.0f;
+        float m_movement_acceleration              = 1000.0f;
+        float m_movement_drag                      = 10.0f;
+        Math::Vector2 m_mouse_smoothed             = Math::Vector2::Zero;
+        Math::Vector2 m_first_person_rotation      = Math::Vector2::Zero;
+        float m_mouse_sensitivity                  = 0.2f;
+        float m_mouse_smoothing                    = 0.5f;
+        bool m_lerp_to_target_p                    = false;
+        bool m_lerp_to_target_r                    = false;
+        bool m_lerpt_to_bookmark                   = false;
+        int m_target_bookmark_index                = -1;
+        float m_lerp_to_target_alpha               = 0.0f;
+        float m_lerp_to_target_distance            = 0.0f;
+        Math::Vector3 m_lerp_to_target_position    = Math::Vector3::Zero;
+        Math::Quaternion m_lerp_to_target_rotation = Math::Quaternion::Identity;
         RHI_Viewport m_last_known_viewport;
         Math::Ray m_ray;
         Math::Frustum m_frustum;


### PR DESCRIPTION
- Fixed the rotation interpolation when pressing the "F" key in the viewport, with an object selected.
- Fixed the position interpolation for objects that are displaced in the scene.
- Slightly modified the way the interpolation duration is calculated.