### PR TITLE
Compile editor on linux

### DIFF
--- a/build_scripts/premake.lua
+++ b/build_scripts/premake.lua
@@ -244,14 +244,24 @@ function editor_project_configuration()
         end
 
         -- Files
-        files
-        {
-            EDITOR_DIR .. "/**.rc",
-            EDITOR_DIR .. "/**.h",
-            EDITOR_DIR .. "/**.cpp",
-            EDITOR_DIR .. "/**.hpp",
-            EDITOR_DIR .. "/**.inl"
-        }
+        if os.target() == "windows" then
+            files
+            {
+                EDITOR_DIR .. "/**.rc",
+                EDITOR_DIR .. "/**.h",
+                EDITOR_DIR .. "/**.cpp",
+                EDITOR_DIR .. "/**.hpp",
+                EDITOR_DIR .. "/**.inl"
+            }
+        else
+            files
+            {
+                EDITOR_DIR .. "/**.h",
+                EDITOR_DIR .. "/**.cpp",
+                EDITOR_DIR .. "/**.hpp",
+                EDITOR_DIR .. "/**.inl"
+            }
+        end
 
         -- Includes
         includedirs { RUNTIME_DIR }

--- a/runtime/Core/FileSystem.h
+++ b/runtime/Core/FileSystem.h
@@ -22,6 +22,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 //= INCLUDES ===========
+#include <vector>
+#include <string>
 #include "Definitions.h"
 //======================
 


### PR DESCRIPTION
Some minor changes in order to compile the editor in linux. 

The main problem was that the windows resource file (`resource.rc`) can't be created on linux by using the `windres` command. As far as I know the resource file holds the files like the logo and embeds it into the executable. That really does not work on linux so I decided to entirely remove it from the linux build.

#66 