### PR TITLE
Edit Discord badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@
   
 #### Status
 ![build_status](https://github.com/PanosK92/SpartanEngine/actions/workflows/workflow.yml/badge.svg)
-[![Discord](https://img.shields.io/discord/677302405263785986?label=Discord)](https://discord.gg/TG5r2BS)
+[![Discord](https://img.shields.io/discord/677302405263785986?logo=discord&label=Discord&color=5865F2&logoColor=white)](https://discord.gg/TG5r2BS)
 
 # Media
 


### PR DESCRIPTION
Use white Discord icon. Use the official Discord logo's color value of 5865F2.