### PR TITLE
Linux: advancements in the build environment

### DIFF
--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /deps &&\
     git clone --recursive --depth=1 https://github.com/GPUOpen-Tools/Compressonator.git; cd Compressonator &&\
     cd scripts/; python3 fetch_dependencies.py; cd .. &&\
     cmake -DOPTION_ENABLE_ALL_APPS=OFF -DOPTION_BUILD_CMP_SDK=ON -DOPTION_CMP_OPENGL=OFF -DOPTION_CMP_QT=OFF -DOPTION_CMP_OPENCV=OFF &&\
-    make; \
+    make -j $(nproc); \
     mkdir /usr/lib/Compressonator; cp cmp_compressonatorlib/compressonator.h /usr/include/compressonator.h &&\
     cp lib/*.a /usr/lib
 
@@ -36,7 +36,7 @@ RUN cd /deps &&\
     unzip FreeImage3180 &&\
     cd FreeImage/ &&\
     git apply ../freeimage.patch &&\
-    make -f Makefile.gnu libfreeimage-3.18.0.so &&\
+    make -f Makefile.gnu libfreeimage-3.18.0.so -j $(nproc) &&\
     cp libfreeimage-3.18.0.so /usr/lib/libFreeImageLib.so &&\
     mkdir /usr/include/FreeImage cp Source/FreeImage.h Source/Utilities.h /usr/include/FreeImage
 

--- a/build_scripts/patches/freeimage.patch
+++ b/build_scripts/patches/freeimage.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile.gnu b/Makefile.gnu
+index 5f2c625..871ffd0 100644
+--- a/Makefile.gnu
++++ b/Makefile.gnu
+@@ -15,7 +15,7 @@ LIBRARIES = -lstdc++
+ 
+ MODULES = $(SRCS:.c=.o)
+ MODULES := $(MODULES:.cpp=.o)
+-CFLAGS ?= -O3 -fPIC -fexceptions -fvisibility=hidden
++CFLAGS ?= -O3 -fPIC -fexceptions -fvisibility=hidden -std=c++14 -Wno-error=all
+ # OpenJPEG
+ CFLAGS += -DOPJ_STATIC
+ # LibRaw
+@@ -23,7 +23,7 @@ CFLAGS += -DNO_LCMS
+ # LibJXR
+ CFLAGS += -DDISABLE_PERF_MEASUREMENT -D__ANSI__
+ CFLAGS += $(INCLUDE)
+-CXXFLAGS ?= -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy
++CXXFLAGS ?= -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy -std=c++14 -Wno-error=all -Wno-narrowing
+ # LibJXR
+ CXXFLAGS += -D__ANSI__
+ CXXFLAGS += $(INCLUDE)
+@@ -54,7 +54,7 @@ dist: FreeImage
+ dos2unix:
+ 	@$(DOS2UNIX) $(SRCS) $(INCLS)
+ 
+-FreeImage: $(STATICLIB) $(SHAREDLIB)
++FreeImage: $(SHAREDLIB)
+ 
+ .c.o:
+ 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
This PR add serveral improvements into the build environment:
- Fixes the missing patches for building *FreeImage*
- Improves build times by using multiple jobs in make

With this PR the environment should be up and ready to work in as before. (Even better than before due to speedups!)

This PR advances on the #66 issue.