### PR TITLE
Shadow bias seam

### DIFF
--- a/data/shaders/shadow_mapping.hlsl
+++ b/data/shaders/shadow_mapping.hlsl
@@ -234,7 +234,7 @@ float4 Shadow_Map(Surface surface, Light light)
     if (light.distance_to_pixel <= light.far)
     {
         // compute world position with normal offset bias to reduce shadow acne
-        float3 normal_offset_bias = surface.normal * (1.0f - saturate(light.n_dot_l)) * light.texel_size.x * 200.0f;
+        float3 normal_offset_bias = surface.normal * (1.0f - saturate(light.n_dot_l)) * light.texel_size.x;
         float3 position_world     = surface.position + normal_offset_bias;
 
         // project to light space


### PR DESCRIPTION
This PR eliminates the constant used in the compute calculation of the world position with normal offset. Its presence was causing significant seams and lighting problems in shadow-mapping. I would appreciate it if you could clarify whether this constant is essential or if its inclusion was an oversight. Based on my tests, its absence does not appear to contribute to any shadow acne issues.

![PR](https://github.com/PanosK92/SpartanEngine/assets/10392484/673ee75c-14cd-4d11-8202-fbc4853896c1)


