### PR TITLE
Further improvements on the build environment

### DIFF
--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -41,5 +41,14 @@ RUN cd /deps &&\
     mkdir /usr/include/FreeImage &&\
     cp Source/FreeImage.h Source/Utilities.h /usr/include/FreeImage
 
+# Download and install OpenImageDenoiser
+RUN cd /deps &&\
+    wget https://github.com/RenderKit/oidn/releases/download/v2.3.0/oidn-2.3.0.x86_64.linux.tar.gz &&\
+    tar xvf oidn-2.3.0.x86_64.linux.tar.gz &&\
+    rm oidn-2.3.0.x86_64.linux.tar.gz &&\
+    cd oidn-2.3.0.x86_64.linux &&\
+    cp -r include/OpenImageDenoise/ /usr/include/OpenImageDenoise &&\
+    cp -r lib/*.so* /usr/lib/
+
 # Clean up all the intermediate directories created for building and installing external dependencies
 RUN rm -rf /deps/

--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Get all the necessary dependencies from the package manager
 RUN apt update -y &&\
-    apt install -y build-essential libassimp-dev librenderdoc-dev libfreetype-dev libbullet-dev libsdl2-dev libspirv-cross-c-shared-dev git python3 libvulkan-dev pkg-config cmake wget unzip python3-pip &&\
+    apt install -y build-essential libassimp-dev librenderdoc-dev libfreetype-dev libbullet-dev libsdl2-dev libspirv-cross-c-shared-dev git python3 libvulkan-dev pkg-config cmake wget unzip p7zip-full python3-pip &&\
     mkdir /deps
 
 RUN pip install requests

--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -2,8 +2,10 @@ FROM ubuntu:22.04
 
 # Get all the necessary dependencies from the package manager
 RUN apt update -y &&\
-    apt install -y build-essential libassimp-dev librenderdoc-dev libfreetype-dev libbullet-dev libsdl2-dev libspirv-cross-c-shared-dev git python3 libvulkan-dev pkg-config cmake wget unzip &&\
+    apt install -y build-essential libassimp-dev librenderdoc-dev libfreetype-dev libbullet-dev libsdl2-dev libspirv-cross-c-shared-dev git python3 libvulkan-dev pkg-config cmake wget unzip python3-pip &&\
     mkdir /deps
+
+RUN pip install requests
 
 # Download and install premake5
 RUN cd /deps &&\

--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -38,7 +38,8 @@ RUN cd /deps &&\
     git apply ../freeimage.patch &&\
     make -f Makefile.gnu libfreeimage-3.18.0.so -j $(nproc) &&\
     cp libfreeimage-3.18.0.so /usr/lib/libFreeImageLib.so &&\
-    mkdir /usr/include/FreeImage cp Source/FreeImage.h Source/Utilities.h /usr/include/FreeImage
+    mkdir /usr/include/FreeImage &&\
+    cp Source/FreeImage.h Source/Utilities.h /usr/include/FreeImage
 
 # Clean up all the intermediate directories created for building and installing external dependencies
 RUN rm -rf /deps/

--- a/build_scripts/generate_project_files.py
+++ b/build_scripts/generate_project_files.py
@@ -203,11 +203,13 @@ def main():
     assets_expected_hash = '59cd3b52b0aa84ed3f9bfc9fdef7af945d3f42e134e8bc8bded2bc9519380b8a'
     
     #Download files with hash checking
-    download_file(library_url, library_destination, library_expected_hash)
+    if sys.argv[1] == "vs2022":
+        download_file(library_url, library_destination, library_expected_hash)
     download_file(assets_url, assets_destination, assets_expected_hash)
     
     # Extract the downloaded files
-    extract_third_party_dependencies()
+    if sys.argv[1] == "vs2022":
+        extract_third_party_dependencies()
     extract_assets()
 
     create_binaries_folder()

--- a/build_scripts/generate_project_files.py
+++ b/build_scripts/generate_project_files.py
@@ -171,9 +171,13 @@ def generate_project_files():
     )
     subprocess.Popen(cmd, shell=True).communicate()
     
-    if not os.path.exists("spartan.sln"):
+    if sys.argv[1] == "vs2022" and not os.path.exists("spartan.sln"):
         print("Error: spartan.sln not generated.")
         sys.exit(1)
+    elif not os.path.exists("Makefile") and not os.path.exists("editor/Makefile") and not os.path.exists("runtime/Makefile"):
+        print("Error: makefiles not generated")
+        sys.exit(1)
+
 
 def print_local_file_hashes():
     local_files = {


### PR DESCRIPTION
This PR further advances the build environment used for building the spartan engine for linux. This PR does the next things:
- Fixes the installation of FreeImage inside the environment.
- Adds OpenImageDenoise to the build environment
- Adds the `7za` binary for use in the project generation
- Optimizes builds by not downloading windows libraries
- Fixes wrong checks when the project generation is finished

This PR further advances on the #66 issue.