### PR TITLE
Fix ResourceType enum

### DIFF
--- a/runtime/Resource/IResource.h
+++ b/runtime/Resource/IResource.h
@@ -33,6 +33,7 @@ namespace Spartan
 {
     enum class ResourceType
     {
+        Unknown,
         Texture,
         Texture2d,
         Texture3d,


### PR DESCRIPTION
This patch fixes a compilation error happening on Linux (that should happen also on windows to be honest) by simply adding the `Unknown` value to the `ResourceType` enumeration.

This is really strange so I might be missing something. 