### PR TITLE
Remove FidelityFX from linux build

### DIFF
--- a/build_scripts/premake.lua
+++ b/build_scripts/premake.lua
@@ -31,7 +31,7 @@ API_CPP_DEFINE		 = ""
 ARG_API_GRAPHICS     = _ARGS[1]
 
 API_INCLUDES = {
-	vulkan = {
+	vulkan_windows = {
         "../third_party/spirv_cross",
         "../third_party/vulkan",
         "../third_party/amd_fidelityfx"
@@ -41,7 +41,8 @@ API_INCLUDES = {
 API_EXCLUDES = 
 {
     d3d12  = { RUNTIME_DIR .. "/RHI/Vulkan/**" },
-    vulkan = { RUNTIME_DIR .. "/RHI/D3D12/**" },
+    vulkan_linux = { RUNTIME_DIR .. "/RHI/D3D12/**" },
+    vulkan_windows = { RUNTIME_DIR .. "/RHI/D3D12/**" },
 }
 
 API_LIBRARIES = {
@@ -53,7 +54,7 @@ API_LIBRARIES = {
             -- No specific D3D12 debug libraries
         }
     },
-    vulkan = {
+    vulkan_windows = {
         release = {
             "spirv-cross-c",
             "spirv-cross-core",
@@ -86,6 +87,22 @@ API_LIBRARIES = {
 			"ffx_brixelizer_x64d",
 			"ffx_brixelizergi_x64d"
         }
+    },
+    vulkan_linux = {
+        release = {
+            "spirv-cross-c",
+            "spirv-cross-core",
+            "spirv-cross-cpp",
+            "spirv-cross-glsl",
+            "spirv-cross-hlsl"
+        },
+        debug = {
+            "spirv-cross-c_debug",
+            "spirv-cross-core_debug",
+            "spirv-cross-cpp_debug",
+            "spirv-cross-glsl_debug",
+            "spirv-cross-hlsl_debug"
+        }
     }
 }
 
@@ -93,7 +110,7 @@ function configure_graphics_api()
     if ARG_API_GRAPHICS == "d3d12" then
         API_CPP_DEFINE  = "API_GRAPHICS_D3D12"
         EXECUTABLE_NAME = EXECUTABLE_NAME .. "_d3d12"
-    elseif ARG_API_GRAPHICS == "vulkan" then
+    elseif ARG_API_GRAPHICS == "vulkan_windows" or ARG_API_GRAPHICS == "vulkan_linux" then
         API_CPP_DEFINE  = "API_GRAPHICS_VULKAN"
         EXECUTABLE_NAME = EXECUTABLE_NAME .. "_vulkan"
     end

--- a/generate_gmake2_vulkan.py
+++ b/generate_gmake2_vulkan.py
@@ -4,6 +4,6 @@ import sys
 # change working directory to script directory
 os.chdir(os.path.dirname(__file__))
 # run script
-subprocess.Popen("python3 build_scripts/generate_project_files.py gmake2 vulkan", shell=True).communicate()
+subprocess.Popen("python3 build_scripts/generate_project_files.py gmake2 vulkan_linux", shell=True).communicate()
 # exit
 sys.exit(0)

--- a/generate_vs2022_vulkan.py
+++ b/generate_vs2022_vulkan.py
@@ -8,7 +8,7 @@ def main():
     os.chdir(script_dir)
 
     script = script_dir / "build_scripts" / "generate_project_files.py"
-    subprocess.Popen([sys.executable, str(script), "vs2022", "vulkan"]).communicate()
+    subprocess.Popen([sys.executable, str(script), "vs2022", "vulkan_windows"]).communicate()
     sys.exit(0)
 
 if __name__ == "__main__":

--- a/runtime/RHI/Vulkan/Vulkan_FidelityFX.cpp
+++ b/runtime/RHI/Vulkan/Vulkan_FidelityFX.cpp
@@ -756,9 +756,7 @@ namespace Spartan
 
     void RHI_FidelityFX::FSR3_ResetHistory()
     {
-    #ifdef _MSC_VER
         fsr3::description_dispatch.reset = true;
-    #endif
     }
 
     void RHI_FidelityFX::FSR3_GenerateJitterSample(float* x, float* y)

--- a/runtime/RHI/Vulkan/Vulkan_FidelityFX.cpp
+++ b/runtime/RHI/Vulkan/Vulkan_FidelityFX.cpp
@@ -19,8 +19,10 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+
 //= INCLUDES ==================================
 #include "pch.h"
+#ifdef _MSC_VER
 #include "../RHI_FidelityFX.h"
 #include "../RHI_Implementation.h"
 #include "../RHI_CommandList.h"
@@ -33,22 +35,28 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../World/Components/Renderable.h"
 #include "../World/Components/Camera.h"
 #include "../World/Entity.h"
+#endif
 SP_WARNINGS_OFF
+#ifdef _MSC_VER
 #include <FidelityFX/host/backends/vk/ffx_vk.h>
 #include <FidelityFX/host/ffx_fsr3.h>
 #include <FidelityFX/host/ffx_sssr.h>
 #include <FidelityFX/host/ffx_brixelizer.h>
 #include <FidelityFX/host/ffx_brixelizergi.h>
+#endif
 SP_WARNINGS_ON
 //=============================================
 
+#ifdef _MSC_VER
 //= NAMESPACES ===============
 using namespace Spartan::Math;
 using namespace std;
 //============================
+#endif
 
 namespace Spartan
 {
+    #ifdef _MSC_VER
     namespace
     {
         // shared among all contexts
@@ -456,9 +464,11 @@ namespace Spartan
             }
         }
     }
+    #endif 
 
     void RHI_FidelityFX::Initialize()
     {
+    #ifdef _MSC_VER
         // ffx interface
         {
             // all used contexts need to be accounted for here
@@ -548,10 +558,12 @@ namespace Spartan
                 }
             }
         }
+    #endif
     }
 
     void RHI_FidelityFX::DestroyContexts()
     {
+    #ifdef _MSC_VER
         // brixelizer gi
         if (brixelizer_gi::context_created)
         {
@@ -579,10 +591,12 @@ namespace Spartan
             fsr3::context_created  = false;
             fsr3::texture_reactive = nullptr;
         }
+    #endif
     }
 
     void RHI_FidelityFX::Shutdown()
     {
+    #ifdef _MSC_VER
         cubemap_empty                          = nullptr;
         brixelizer_gi::texture_sdf_atlas       = nullptr;
         brixelizer_gi::buffer_brick_aabbs      = nullptr;
@@ -599,10 +613,12 @@ namespace Spartan
         {
             free(ffx_interface.scratchBuffer);
         }
+    #endif
     }
 
     void RHI_FidelityFX::Resize(const Vector2& resolution_render, const Vector2& resolution_output)
     {
+    #ifdef _MSC_VER
         // contexts are resolution dependent, so we destroy and (re)create them when resizing
         DestroyContexts();
 
@@ -695,10 +711,12 @@ namespace Spartan
 
             brixelizer_gi::context_created = true;
         }
+    #endif
     }
  
     void RHI_FidelityFX::Update(Cb_Frame* cb_frame)
     {
+    #ifdef _MSC_VER
         // matrices - ffx is right-handed
         {
             view_previous            = view;
@@ -733,15 +751,19 @@ namespace Spartan
             }
 
         }
+    #endif
     }
 
     void RHI_FidelityFX::FSR3_ResetHistory()
     {
+    #ifdef _MSC_VER
         fsr3::description_dispatch.reset = true;
+    #endif
     }
 
     void RHI_FidelityFX::FSR3_GenerateJitterSample(float* x, float* y)
     {
+    #ifdef _MSC_VER
         // get jitter phase count
         const uint32_t resolution_render_x = static_cast<uint32_t>(fsr3::description_context.maxRenderSize.width);
         const uint32_t resolution_render_y = static_cast<uint32_t>(fsr3::description_context.maxRenderSize.height);
@@ -757,6 +779,7 @@ namespace Spartan
         // adjust the jitter offset for the projection matrix, based on the function comments
         *x =  2.0f * fsr3::description_dispatch.jitterOffset.x / resolution_render_x;
         *y = -2.0f * fsr3::description_dispatch.jitterOffset.y / resolution_render_y;
+    #endif
     }
 
     void RHI_FidelityFX::FSR3_Dispatch
@@ -774,6 +797,7 @@ namespace Spartan
         RHI_Texture* tex_output
     )
     {
+    #ifdef _MSC_VER
         // documentation: https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/main/docs/techniques/super-resolution-upscaler.md
         // requires:      VK_KHR_get_memory_requirements2
 
@@ -828,6 +852,7 @@ namespace Spartan
             SP_ASSERT(ffxFsr3UpscalerContextDispatch(&fsr3::context, &fsr3::description_dispatch) == FFX_OK);
             fsr3::description_dispatch.reset = false;
         }
+    #endif
     }
 
     void RHI_FidelityFX::SSSR_Dispatch(
@@ -842,6 +867,7 @@ namespace Spartan
         RHI_Texture* tex_output
     )
     {
+    #ifdef _MSC_VER
         // documentation: https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/main/docs/techniques/stochastic-screen-space-reflections.md
 
         // transition the depth to shader read, to avoid validation errors caused by ffx
@@ -893,6 +919,7 @@ namespace Spartan
         // dispatch
         FfxErrorCode error_code = ffxSssrContextDispatch(&sssr::context, &sssr::description_dispatch);
         SP_ASSERT(error_code == FFX_OK);
+    #endif
     }
 
     void RHI_FidelityFX::BrixelizerGI_Update(
@@ -904,6 +931,7 @@ namespace Spartan
         RHI_Texture* tex_debug
     )
     {
+    #ifdef _MSC_VER
         // documentation: https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/main/docs/techniques/brixelizer.md
         // documentation: https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/main/docs/techniques/brixelizer-gi.md
 
@@ -1074,6 +1102,7 @@ namespace Spartan
         SP_ASSERT(ffxBrixelizerBakeUpdate(&brixelizer_gi::context, &brixelizer_gi::description_update, &brixelizer_gi::description_update_baked) == FFX_OK);
         SP_ASSERT_MSG(required_scratch_buffer_size <= brixelizer_gi::buffer_scratch->GetObjectSize(), "Create a larger scratch buffer");
         SP_ASSERT(ffxBrixelizerUpdate(&brixelizer_gi::context, &brixelizer_gi::description_update_baked, to_ffx_resource(brixelizer_gi::buffer_scratch.get(), L"ffx_brixelizer_gi_scratch"), to_ffx_cmd_list(cmd_list)) == FFX_OK);
+    #endif
     }
 
     void RHI_FidelityFX::BrixelizerGI_Dispatch(
@@ -1090,6 +1119,7 @@ namespace Spartan
         RHI_Texture* tex_debug
     )
     {
+    #ifdef _MSC_VER
         // documentation: https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/main/docs/techniques/brixelizer.md
         // documentation: https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/main/docs/techniques/brixelizer-gi.md
 
@@ -1184,5 +1214,6 @@ namespace Spartan
             brixelizer_gi::debug_description_gi.brixelizerContext = brixelizer_gi::description_dispatch_gi.brixelizerContext;
             SP_ASSERT(ffxBrixelizerGIContextDebugVisualization(&brixelizer_gi::context_gi, &brixelizer_gi::debug_description_gi, to_ffx_cmd_list(cmd_list)) == FFX_OK);
         }
+    #endif
     }
 }

--- a/runtime/Rendering/Renderer_Passes.cpp
+++ b/runtime/Rendering/Renderer_Passes.cpp
@@ -29,7 +29,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../RHI/RHI_CommandList.h"
 #include "../RHI/RHI_Buffer.h"
 #include "../RHI/RHI_Shader.h"
+#ifdef _MSC_VER
 #include "../RHI/RHI_FidelityFX.h"
+#endif
 #include "../RHI/RHI_RasterizerState.h"
 SP_WARNINGS_OFF
 #include "bend_sss_cpu.h"
@@ -943,6 +945,7 @@ namespace Spartan
 
     void Renderer::Pass_Ssr(RHI_CommandList* cmd_list)
     {
+        #ifdef _MSC_VER
         static bool cleared = true;
 
         if (GetOption<bool>(Renderer_Option::ScreenSpaceReflections))
@@ -970,6 +973,7 @@ namespace Spartan
             cmd_list->ClearTexture(GetRenderTarget(Renderer_RenderTarget::ssr).get(), Color::standard_transparent);
             cleared = true;
         }
+        #endif
     }
 
     void Renderer::Pass_Sss(RHI_CommandList* cmd_list)
@@ -1179,6 +1183,7 @@ namespace Spartan
 
     void Renderer::Pass_Light_GlobalIllumination(RHI_CommandList* cmd_list)
     {
+        #ifdef _MSC_VER
         static bool cleared = true;
 
         if (GetOption<bool>(Renderer_Option::GlobalIllumination) && m_initialized_third_party)
@@ -1240,6 +1245,7 @@ namespace Spartan
             cmd_list->ClearTexture(GetRenderTarget(Renderer_RenderTarget::light_specular_gi).get(), Color::standard_black);
             cleared = true;
         }
+        #endif
     }
 
     void Renderer::Pass_Light_Composition(RHI_CommandList* cmd_list, const bool is_transparent_pass)
@@ -1741,6 +1747,7 @@ namespace Spartan
 
     void Renderer::Pass_Upscale(RHI_CommandList* cmd_list)
     {
+        #ifdef _MSC_VER
         // acquire render targets
         RHI_Texture* tex_in  = GetRenderTarget(Renderer_RenderTarget::frame_render).get();
         RHI_Texture* tex_out = GetRenderTarget(Renderer_RenderTarget::frame_output).get();
@@ -1769,6 +1776,7 @@ namespace Spartan
         }
 
         cmd_list->EndTimeblock();
+        #endif
     }
 
     void Renderer::Pass_Sharpening(RHI_CommandList* cmd_list, RHI_Texture* tex_in, RHI_Texture* tex_out)

--- a/runtime/Rendering/Renderer_Passes.cpp
+++ b/runtime/Rendering/Renderer_Passes.cpp
@@ -945,7 +945,6 @@ namespace Spartan
 
     void Renderer::Pass_Ssr(RHI_CommandList* cmd_list)
     {
-        #ifdef _MSC_VER
         static bool cleared = true;
 
         if (GetOption<bool>(Renderer_Option::ScreenSpaceReflections))
@@ -973,7 +972,6 @@ namespace Spartan
             cmd_list->ClearTexture(GetRenderTarget(Renderer_RenderTarget::ssr).get(), Color::standard_transparent);
             cleared = true;
         }
-        #endif
     }
 
     void Renderer::Pass_Sss(RHI_CommandList* cmd_list)
@@ -1183,7 +1181,6 @@ namespace Spartan
 
     void Renderer::Pass_Light_GlobalIllumination(RHI_CommandList* cmd_list)
     {
-        #ifdef _MSC_VER
         static bool cleared = true;
 
         if (GetOption<bool>(Renderer_Option::GlobalIllumination) && m_initialized_third_party)
@@ -1245,7 +1242,6 @@ namespace Spartan
             cmd_list->ClearTexture(GetRenderTarget(Renderer_RenderTarget::light_specular_gi).get(), Color::standard_black);
             cleared = true;
         }
-        #endif
     }
 
     void Renderer::Pass_Light_Composition(RHI_CommandList* cmd_list, const bool is_transparent_pass)
@@ -1747,7 +1743,6 @@ namespace Spartan
 
     void Renderer::Pass_Upscale(RHI_CommandList* cmd_list)
     {
-        #ifdef _MSC_VER
         // acquire render targets
         RHI_Texture* tex_in  = GetRenderTarget(Renderer_RenderTarget::frame_render).get();
         RHI_Texture* tex_out = GetRenderTarget(Renderer_RenderTarget::frame_output).get();
@@ -1776,7 +1771,6 @@ namespace Spartan
         }
 
         cmd_list->EndTimeblock();
-        #endif
     }
 
     void Renderer::Pass_Sharpening(RHI_CommandList* cmd_list, RHI_Texture* tex_in, RHI_Texture* tex_out)

--- a/runtime/Rendering/Renderer_Resources.cpp
+++ b/runtime/Rendering/Renderer_Resources.cpp
@@ -270,9 +270,7 @@ namespace Spartan
         
 
         RHI_Device::QueueWaitAll();
-        #ifdef _MSC_VER
         RHI_FidelityFX::Resize(GetResolutionRender(), GetResolutionOutput());
-        #endif
     }
 
     void Renderer::CreateShaders()

--- a/runtime/Rendering/Renderer_Resources.cpp
+++ b/runtime/Rendering/Renderer_Resources.cpp
@@ -34,7 +34,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../RHI/RHI_RasterizerState.h"
 #include "../RHI/RHI_DepthStencilState.h"
 #include "../RHI/RHI_Buffer.h"
+#ifdef _MSC_VER
 #include "../RHI/RHI_FidelityFX.h"
+#endif
 #include "../RHI/RHI_Device.h"
 //=======================================
 
@@ -268,7 +270,9 @@ namespace Spartan
         
 
         RHI_Device::QueueWaitAll();
+        #ifdef _MSC_VER
         RHI_FidelityFX::Resize(GetResolutionRender(), GetResolutionOutput());
+        #endif
     }
 
     void Renderer::CreateShaders()


### PR DESCRIPTION
This PR removes support from linux builds for now. The SDK is not currently available officially for linux so its better to remove the dependency for now.

Status:
- [x] Don't compile FidelityFX related code
- [x] Don't link to FidelityFX SDK libraries