### PR TITLE
Implementing circular stack for Command Stack

### DIFF
--- a/runtime/Commands/CircularStack.h
+++ b/runtime/Commands/CircularStack.h
@@ -1,0 +1,101 @@
+/*
+Copyright(c) 2024 Roman Koshchei
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+//= INCLUDES ===================
+#include <optional>
+//==============================
+
+//= NAMESPACES =====
+using namespace std;
+//==================
+
+namespace Spartan
+{
+    template <typename T>
+    class CircularStack {
+    private:
+        uint64_t top_item_index;
+        uint64_t items_count;
+
+        uint64_t buffer_capacity;
+        T* buffer_start;
+
+    public:
+        CircularStack(uint64_t capacity);
+        ~CircularStack();
+
+        void Push(T item);
+        optional<T> Pop();
+        void Clear();
+    };
+
+    template <typename T>
+    CircularStack<T>::CircularStack(uint64_t capacity): buffer_capacity(capacity), items_count(0) {
+        this->buffer_start = new T[capacity];
+        this->top_item_index = capacity - 1;
+    }
+
+    template <typename T>
+    CircularStack<T>::~CircularStack() {
+        delete[] buffer_start;
+    }
+
+    template <typename T>
+    void CircularStack<T>::Push(T item) {
+        top_item_index += 1;
+        if (top_item_index == buffer_capacity) {
+            top_item_index = 0;
+        }
+
+        buffer_start[top_item_index] = item;
+
+        items_count += 1;
+        if (items_count > buffer_capacity) {
+            items_count = buffer_capacity;
+        }
+    }
+
+    template <typename T>
+    optional<T> CircularStack<T>::Pop() {
+        if (items_count == 0) {
+            return nullopt;
+        }
+
+        T item = buffer_start[top_item_index];
+
+        top_item_index -= 1;
+        if (top_item_index < 0) {
+            top_item_index = buffer_capacity - 1;
+        }
+
+        items_count -= 1;
+
+        return item;
+    }
+
+    template <typename T>
+    void CircularStack<T>::Clear() {
+        this->items_count = 0;
+        this->top_item_index = this->buffer_capacity - 1;
+    }
+};

--- a/runtime/Commands/CircularStack.h
+++ b/runtime/Commands/CircularStack.h
@@ -69,9 +69,8 @@ namespace Spartan
 
         buffer_start[top_item_index] = item;
 
-        items_count += 1;
-        if (items_count > buffer_capacity) {
-            items_count = buffer_capacity;
+        if (items_count < buffer_capacity) {
+            items_count += 1;
         }
     }
 
@@ -83,9 +82,11 @@ namespace Spartan
 
         T item = buffer_start[top_item_index];
 
-        top_item_index -= 1;
-        if (top_item_index < 0) {
+        if (top_item_index == 0) {
             top_item_index = buffer_capacity - 1;
+        }
+        else {
+            top_item_index -= 1;
         }
 
         items_count -= 1;

--- a/runtime/Commands/CircularStack.h
+++ b/runtime/Commands/CircularStack.h
@@ -25,10 +25,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <optional>
 //==============================
 
-//= NAMESPACES =====
-using namespace std;
-//==================
-
 namespace Spartan
 {
     template <typename T>
@@ -45,7 +41,7 @@ namespace Spartan
         ~CircularStack();
 
         void Push(T item);
-        optional<T> Pop();
+        std::optional<T> Pop();
         void Clear();
     };
 
@@ -75,9 +71,9 @@ namespace Spartan
     }
 
     template <typename T>
-    optional<T> CircularStack<T>::Pop() {
+    std::optional<T> CircularStack<T>::Pop() {
         if (items_count == 0) {
-            return nullopt;
+            return std::nullopt;
         }
 
         T item = buffer_start[top_item_index];

--- a/runtime/Commands/CommandStack.h
+++ b/runtime/Commands/CommandStack.h
@@ -39,9 +39,9 @@ public:
         // could be solved by using linked lists instead of dynamic arrays (vectors)
         // optimal solution may be to preallocate an array instead, and use a cursor to manage undo/redo <-- probably do this
         // luckily we only store pointers so should be decent performance for now (as long as max_undo_steps doesn't grow too large)
-        /*if (m_undo_buffer.size() >= max_undo_steps) {
-            m_undo_buffer.erase(m_undo_buffer.begin());
-        }*/
+        //
+        // CircularStack author: not sure I fully made optimal solution
+        // I suppose we can store it all in single stack, I will look into it
 
         std::shared_ptr<Command> new_command = std::make_shared<CommandType>(std::forward<Args>(args)...);
         m_undo_buffer.Push(new_command);

--- a/runtime/Commands/CommandStack.h
+++ b/runtime/Commands/CommandStack.h
@@ -24,43 +24,40 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //= INCLUDES ===================
 #include "Definitions.h"
 #include "../Commands/Command.h"
+#include "../Commands/CircularStack.h"
 //==============================
 
-namespace Spartan
-{
-    // @todo make editor setting instead of compile time constant expression
-    constexpr uint64_t max_undo_steps = 128;
+namespace Spartan {
+// @todo make editor setting instead of compile time constant expression
+constexpr uint64_t max_undo_steps = 128;
 
-    class SP_CLASS CommandStack
-    {
-    public: 
-        template<typename CommandType, typename... Args>
-        static void Add(Args&&... args)
-        {
-            // @todo this is garbage for performance, as it has to copy the entire buffer when it's full
-            // could be solved by using linked lists instead of dynamic arrays (vectors)
-            // optimal solution may be to preallocate an array instead, and use a cursor to manage undo/redo <-- probably do this
-            // luckily we only store pointers so should be decent performance for now (as long as max_undo_steps doesn't grow too large)
-            if (m_undo_buffer.size() >= max_undo_steps)
-            {
-                m_undo_buffer.erase(m_undo_buffer.begin());
-            }
+class SP_CLASS CommandStack {
+public:
+    template<typename CommandType, typename... Args>
+    static void Add(Args&&... args) {
+        // @todo this is garbage for performance, as it has to copy the entire buffer when it's full
+        // could be solved by using linked lists instead of dynamic arrays (vectors)
+        // optimal solution may be to preallocate an array instead, and use a cursor to manage undo/redo <-- probably do this
+        // luckily we only store pointers so should be decent performance for now (as long as max_undo_steps doesn't grow too large)
+        /*if (m_undo_buffer.size() >= max_undo_steps) {
+            m_undo_buffer.erase(m_undo_buffer.begin());
+        }*/
 
-            std::shared_ptr<Command> new_command = std::make_shared<CommandType>(std::forward<Args>(args)...);
-            m_undo_buffer.push_back(new_command);
+        std::shared_ptr<Command> new_command = std::make_shared<CommandType>(std::forward<Args>(args)...);
+        m_undo_buffer.Push(new_command);
 
-            // Make sure to clear the redo buffer if you apply a new command, to preserve the time continuum.
-            m_redo_buffer.clear();
-        }
+        // Make sure to clear the redo buffer if you apply a new command, to preserve the time continuum.
+        m_redo_buffer.Clear();
+    }
 
-        /** Undoes the latest applied command */
-        static void Undo();
+    /** Undoes the latest applied command */
+    static void Undo();
 
-        /** Redoes the latest undone command */
-        static void Redo();
+    /** Redoes the latest undone command */
+    static void Redo();
 
-    protected:
-        static std::vector<std::shared_ptr<Command>> m_undo_buffer;
-        static std::vector<std::shared_ptr<Command>> m_redo_buffer;
-    };
+protected:
+    static Spartan::CircularStack<std::shared_ptr<Command>> m_undo_buffer;
+    static Spartan::CircularStack<std::shared_ptr<Command>> m_redo_buffer;
+};
 }


### PR DESCRIPTION
I added CircularStack, which is a fixed size stack that goes around if there is no more space to add new items.
It's related to the comment:

```cpp
// @todo this is garbage for performance, as it has to copy the entire buffer when it's full
// could be solved by using linked lists instead of dynamic arrays (vectors)
// optimal solution may be to preallocate an array instead, and use a cursor to manage undo/redo <-- probably do this
// luckily we only store pointers so should be decent performance for now (as long as max_undo_steps doesn't grow too large)
```

I am sure we can make it even better by using only 1 stack instead of 2 for undo and redo commands. But I just wanted to make the initial step. I am not a game dev, but I like implementing data structures, so here it is.

Code is tested in my another project works fine. Currently, size type is hard-coded based on `max_undo_steps` type, but it can also be put into a template later.

Waiting for a feedback.