### PR TITLE
Update Vector3.h

### DIFF
--- a/source/runtime/Math/Vector3.h
+++ b/source/runtime/Math/Vector3.h
@@ -65,7 +65,7 @@ namespace spartan::math
             z = f;
         }
 
-        bool Normalize()
+        void Normalize()
         {
             const auto length_squared = LengthSquared();
             if (!approximate_equals(length_squared, 1.0f) && length_squared > 0.0f)


### PR DESCRIPTION
Changed Vector3::Normalize() return value to bool to check for failure when length is 0.0f and zero the vector in zero case. since to ensure consistency, you should not return NaN or any other null value. The normalized form of v=0 is indeed v=0.