### PR TITLE
Fix crash on swapchain resize

### DIFF
--- a/source/runtime/RHI/RHI_SwapChain.h
+++ b/source/runtime/RHI/RHI_SwapChain.h
@@ -92,6 +92,7 @@ namespace spartan
         uint32_t m_image_index   = 0;
         uint32_t semaphore_index = 0;
         void* m_sdl_window       = nullptr;
+        subscription_handle m_window_resize_event_handle;
         std::array<std::shared_ptr<RHI_SyncPrimitive>, buffer_count> m_image_acquired_semaphore;
 
         // rhi

--- a/source/runtime/RHI/Vulkan/Vulkan_SwapChain.cpp
+++ b/source/runtime/RHI/Vulkan/Vulkan_SwapChain.cpp
@@ -288,11 +288,14 @@ namespace spartan
 
         Create();
     
-        SP_SUBSCRIBE_TO_EVENT(EventType::WindowResized, SP_EVENT_HANDLER(ResizeToWindowSize));
+        m_window_resize_event_handle = SP_SUBSCRIBE_TO_EVENT(EventType::WindowResized, SP_EVENT_HANDLER(ResizeToWindowSize));
     }
 
     RHI_SwapChain::~RHI_SwapChain()
     {
+        SP_UNSUBSCRIBE_FROM_EVENT(EventType::WindowResized, m_window_resize_event_handle);
+        m_window_resize_event_handle = 0;
+
         for (void*& image_view : m_rhi_rtv)
         {
             if (image_view)


### PR DESCRIPTION
The swapchain now unsubscribes itself from the window resize event when it's destroyed.