### PR TITLE
Create Volume Component

### DIFF
--- a/source/editor/Widgets/Properties.h
+++ b/source/editor/Widgets/Properties.h
@@ -40,6 +40,7 @@ namespace spartan
     class AudioSource;
     class Script;
     class Terrain;
+    class Volume;
     class ReflectionProbe;
     class Component;
 }
@@ -66,6 +67,7 @@ private:
     void ShowCamera(spartan::Camera* camera) const;
     void ShowTerrain(spartan::Terrain* terrain) const;
     void ShowAudioSource(spartan::AudioSource* audio_source) const;
+    void ShowVolume(spartan::Volume* volume) const;
 
     void ShowAddComponentButton() const;
     void ComponentContextMenu_Add() const;

--- a/source/editor/Widgets/WorldViewer.cpp
+++ b/source/editor/Widgets/WorldViewer.cpp
@@ -33,6 +33,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "Commands/CommandStack.h"
 #include "Input/Input.h"
 #include "../ImGui/ImGui_Extension.h"
+#include "World/Components/Volume.h"
 SP_WARNINGS_OFF
 #include "../ImGui/Source/imgui_stdlib.h"
 SP_WARNINGS_ON
@@ -563,6 +564,12 @@ void WorldViewer::PopupContextMenu() const
         ActionEntityCreateTerrain();
     }
 
+    // VOLUME
+    if (ImGui::MenuItem("Volume"))
+    {
+        ActionEntityCreateVolume();
+    }
+
     ImGui::EndPopup();
 }
 
@@ -778,3 +785,12 @@ void WorldViewer::ActionEntityCreateAudioSource()
     entity->AddComponent<spartan::AudioSource>();
     entity->SetObjectName("Physics");
 }
+
+void WorldViewer::ActionEntityCreateVolume()
+{
+    auto entity = ActionEntityCreateEmpty();
+    entity->AddComponent<spartan::Volume>();
+    entity->SetObjectName("Volume");
+}
+
+

--- a/source/editor/Widgets/WorldViewer.h
+++ b/source/editor/Widgets/WorldViewer.h
@@ -65,4 +65,5 @@ private:
     static void ActionEntityCreateLightSpot();
     static void ActionEntityCreatePhysicsBody();
     static void ActionEntityCreateAudioSource();
+    static void ActionEntityCreateVolume();
 };

--- a/source/runtime/Game/Game.cpp
+++ b/source/runtime/Game/Game.cpp
@@ -290,10 +290,10 @@ namespace spartan
         void set_base_renderer_options()
          {
              // disable all effects which are specific to certain worlds, let the each world decide which effects it wants to enable
-             Renderer::SetOption(Renderer_Option::Dithering,           0.0f);
-             Renderer::SetOption(Renderer_Option::ChromaticAberration, 0.0f);
-             Renderer::SetOption(Renderer_Option::Grid,                0.0f);
-             Renderer::SetOption(Renderer_Option::Vhs,                 0.0f);
+             Renderer::SetOption(Renderer_Option::Dithering,           false);
+             Renderer::SetOption(Renderer_Option::ChromaticAberration, false);
+             Renderer::SetOption(Renderer_Option::Grid,                false);
+             Renderer::SetOption(Renderer_Option::Vhs,                 false);
          }
     }
 
@@ -1343,9 +1343,9 @@ namespace spartan
 
                 // adjust renderer options
                 {
-                    Renderer::SetOption(Renderer_Option::PerformanceMetrics, 0.0f);
-                    Renderer::SetOption(Renderer_Option::Lights,             0.0f);
-                    Renderer::SetOption(Renderer_Option::Dithering,          0.0f);
+                    Renderer::SetOption(Renderer_Option::PerformanceMetrics, false);
+                    Renderer::SetOption(Renderer_Option::Lights,             false);
+                    Renderer::SetOption(Renderer_Option::Dithering,          false);
                 }
             }
 
@@ -1459,8 +1459,8 @@ namespace spartan
                 }
             
                 // renderer options
-                Renderer::SetOption(Renderer_Option::ChromaticAberration, 1.0f);
-                Renderer::SetOption(Renderer_Option::Vhs, 1.0f);
+                Renderer::SetOption(Renderer_Option::ChromaticAberration, true);
+                Renderer::SetOption(Renderer_Option::Vhs, true);
             
                 // camera
                 entities::camera(Vector3(5.4084f, 1.8f, 4.7593f));

--- a/source/runtime/Math/Vector3.h
+++ b/source/runtime/Math/Vector3.h
@@ -117,6 +117,13 @@ namespace spartan::math
             return std::max(std::max(x, y), z);
         }
 
+        Vector3 Max(const Vector3& other)
+        {
+            return {std::max(x, other.x),
+                       std::max(y, other.y),
+                       std::max(z, other.z)};
+        }
+
         [[nodiscard]] static float Dot(const Vector3& v1, const Vector3& v2) 
         { 
             return (v1.x * v2.x + v1.y * v2.y + v1.z * v2.z);

--- a/source/runtime/Rendering/RenderOptionsPool.cpp
+++ b/source/runtime/Rendering/RenderOptionsPool.cpp
@@ -1,0 +1,271 @@
+﻿/*
+Copyright(c) 2015-2025 Panos Karabelas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+//= INCLUDES =================================
+#include "pch.h"
+#include "RenderOptionsPool.h"
+//============================================
+
+#include "Display/Display.h"
+#include "Profiling/Profiler.h"
+#include "Rendering/Renderer.h"
+#include "RHI/RHI_Device.h"
+#include "RHI/RHI_SwapChain.h"
+#include "RHI/RHI_VendorTechnology.h"
+//============================================
+
+//= NAMESPACES ===============
+using namespace std;
+using namespace spartan::math;
+//============================
+
+namespace spartan
+{
+    RenderOptionsPool::RenderOptionsPool() : RenderOptionsPool(RenderOptionsListType::Global)
+    {
+
+    }
+
+    RenderOptionsPool::RenderOptionsPool(const RenderOptionsListType list_type)
+    {
+        m_options.clear();
+        m_options[Renderer_Option::WhitePoint] =                  350.0f; // float
+        m_options[Renderer_Option::Tonemapping] =                 static_cast<uint32_t>(Renderer_Tonemapping::Max); // enum
+        m_options[Renderer_Option::Bloom] =                       1.0f;  // non-zero values activate it and control the intensity, float
+        m_options[Renderer_Option::MotionBlur] =                  true;  // bool
+        m_options[Renderer_Option::DepthOfField] =                true;  // bool
+        m_options[Renderer_Option::FilmGrain] =                   false; // bool
+        m_options[Renderer_Option::ChromaticAberration] =         false; // bool
+        m_options[Renderer_Option::Vhs] =                         false; // bool
+        m_options[Renderer_Option::Dithering] =                   false; // bool
+        m_options[Renderer_Option::ScreenSpaceAmbientOcclusion] = true;  // bool
+        m_options[Renderer_Option::ScreenSpaceReflections] =      true;  // bool
+        m_options[Renderer_Option::RayTracedReflections] =        RHI_Device::IsSupportedRayTracing(); // bool
+        m_options[Renderer_Option::Fog] =                         1.0f;  // float
+        m_options[Renderer_Option::VariableRateShading] =         false; // bool
+        m_options[Renderer_Option::Vsync] =                       false; // bool
+        m_options[Renderer_Option::TransformHandle] =             true;  // bool
+        m_options[Renderer_Option::SelectionOutline] =            false; // bool
+        m_options[Renderer_Option::Grid] =                        false; // bool
+        m_options[Renderer_Option::Lights] =                      true;  // bool
+        m_options[Renderer_Option::AudioSources] =                true;  // bool
+        m_options[Renderer_Option::Physics] =                     false; // bool
+        m_options[Renderer_Option::PerformanceMetrics] =          true;  // bool
+        m_options[Renderer_Option::Gamma] =                       Display::GetGamma(); // float
+        m_options[Renderer_Option::Hdr] =                         false; // bool
+        m_options[Renderer_Option::AutoExposureAdaptationSpeed] = 0.5f;  // float
+
+        if (list_type == RenderOptionsListType::Global) // Global is default (For Render Options Window)
+        {
+            m_options[Renderer_Option::Aabb] =                        false; // bool
+            m_options[Renderer_Option::PickingRay] =                  false; // bool
+            m_options[Renderer_Option::Wireframe] =                   false; // bool
+            m_options[Renderer_Option::Anisotropy] =                  16.0f; // float
+            m_options[Renderer_Option::Sharpness] =                   1.0f;  // float
+            m_options[Renderer_Option::AntiAliasing_Upsampling] =     static_cast<uint32_t>(Renderer_AntiAliasing_Upsampling::AA_Fsr_Upscale_Fsr); // enum
+            m_options[Renderer_Option::ResolutionScale] =             1.0f;  // float
+            m_options[Renderer_Option::DynamicResolution] =           false; // bool
+            m_options[Renderer_Option::OcclusionCulling] =            false; // bool
+        }
+    }
+
+    RenderOptionsPool::RenderOptionsPool(const std::map<Renderer_Option, RenderOptionType>& options)
+    {
+        m_options.clear();
+        m_options = options;
+    }
+
+    RenderOptionsPool::RenderOptionsPool(RenderOptionsPool& other)
+    {
+        m_options.clear();
+        for (const auto& [key, value] : other.m_options)
+        {
+            m_options[key] = value; // replaces if key exists, inserts otherwise
+        }
+    }
+
+    void RenderOptionsPool::SetOption(Renderer_Option option, const RenderOptionType& value)
+    {
+        // Handle clamping for float options
+        if (std::holds_alternative<float>(value))
+        {
+            float v = std::get<float>(value);
+
+            if (option == Renderer_Option::Anisotropy)
+            {
+                v = clamp(v, 0.0f, 16.0f);
+            }
+            else if (option == Renderer_Option::ResolutionScale)
+            {
+                v = clamp(v, 0.5f, 1.0f);
+            }
+
+            // HDR, VRS, etc. validation (float enums)
+            if (option == Renderer_Option::Hdr && v == 1.0f && !Display::GetHdr())
+            {
+                SP_LOG_WARNING("This display doesn't support HDR");
+                return;
+            }
+            else if (option == Renderer_Option::VariableRateShading && v == 1.0f && !RHI_Device::IsSupportedVrs())
+            {
+                SP_LOG_WARNING("This GPU doesn't support variable rate shading");
+                return;
+            }
+
+            m_options[option] = v;
+        }
+        else if (std::holds_alternative<bool>(value))
+        {
+            bool v = std::get<bool>(value);
+
+            m_options[option] = v;
+
+            // cascade for toggles
+            if (option == Renderer_Option::Vsync && Renderer::GetSwapChain())
+            {
+                Renderer::GetSwapChain()->SetVsync(v);
+            }
+            else if (option == Renderer_Option::PerformanceMetrics)
+            {
+                static bool enabled = false;
+                if (!enabled && v)
+                    Profiler::ClearMetrics();
+                enabled = v;
+            }
+        }
+        else if (std::holds_alternative<uint32_t>(value))
+        {
+            uint32_t v = std::get<uint32_t>(value);
+            m_options[option] = v;
+        }
+        else if (std::holds_alternative<int>(value))
+        {
+            int v = std::get<int>(value);
+            m_options[option] = v;
+        }
+
+        // ---- Cascading logic after setting ----
+        if (std::holds_alternative<float>(value))
+        {
+            float v = std::get<float>(value);
+
+            if (option == Renderer_Option::AntiAliasing_Upsampling)
+            {
+                if (v == static_cast<float>(Renderer_AntiAliasing_Upsampling::AA_Fsr_Upscale_Fsr) ||
+                    v == static_cast<float>(Renderer_AntiAliasing_Upsampling::AA_Xess_Upscale_Xess))
+                {
+                    RHI_VendorTechnology::ResetHistory();
+                }
+            }
+            else if (option == Renderer_Option::Hdr && Renderer::GetSwapChain())
+            {
+                Renderer::GetSwapChain()->SetHdr(v == 1.0f);
+            }
+        }
+    }
+
+    bool RenderOptionsPool::operator!=(const RenderOptionsPool& other) const
+    {
+        return m_options != other.m_options;
+    }
+
+    // For Editor
+    std::string RenderOptionsPool::EnumToString(Renderer_Option option)
+    {
+        switch (option)
+        {
+            case Renderer_Option::Aabb:                        return "AABB";
+            case Renderer_Option::PickingRay:                  return "Picking Ray";
+            case Renderer_Option::Grid:                        return "Grid";
+            case Renderer_Option::TransformHandle:             return "Transform Handle";
+            case Renderer_Option::SelectionOutline:            return "Selection Outline";
+            case Renderer_Option::Lights:                      return "Lights";
+            case Renderer_Option::AudioSources:                return "Audio Sources";
+            case Renderer_Option::PerformanceMetrics:          return "Performance Metrics";
+            case Renderer_Option::Physics:                     return "Physics";
+            case Renderer_Option::Wireframe:                   return "Wireframe";
+            case Renderer_Option::Bloom:                       return "Bloom";
+            case Renderer_Option::Fog:                         return "Fog";
+            case Renderer_Option::ScreenSpaceAmbientOcclusion: return "Ambient Occlusion (SSAO)";
+            case Renderer_Option::ScreenSpaceReflections:      return "Reflections (SSR)";
+            case Renderer_Option::RayTracedReflections:        return "Reflections (Ray Traced)";
+            case Renderer_Option::MotionBlur:                  return "Motion Blur";
+            case Renderer_Option::DepthOfField:                return "Depth Of Field";
+            case Renderer_Option::FilmGrain:                   return "Film Grain";
+            case Renderer_Option::Vhs:                         return "VHS Effect";
+            case Renderer_Option::ChromaticAberration:         return "Chromatic Aberration";
+            case Renderer_Option::Anisotropy:                  return "Anisotropy";
+            case Renderer_Option::Tonemapping:                 return "Tone Mapping";
+            case Renderer_Option::AntiAliasing_Upsampling:     return "Anti-Aliasing Upsampling";
+            case Renderer_Option::Sharpness:                   return "Sharpness";
+            case Renderer_Option::Dithering:                   return "Dithering";
+            case Renderer_Option::Hdr:                         return "HDR";
+            case Renderer_Option::WhitePoint:                  return "White Point";
+            case Renderer_Option::Gamma:                       return "Gamma";
+            case Renderer_Option::Vsync:                       return "VSync";
+            case Renderer_Option::VariableRateShading:         return "Variable Rate Shading";
+            case Renderer_Option::ResolutionScale:             return "Resolution Scale";
+            case Renderer_Option::DynamicResolution:           return "Dynamic Resolution";
+            case Renderer_Option::OcclusionCulling:            return "Occlusion Culling";
+            case Renderer_Option::AutoExposureAdaptationSpeed: return "Exposure Adaptation Speed";
+            default:                                           return "Max";
+        }
+    }
+
+    Renderer_Option RenderOptionsPool::StringToEnum(const std::string& name)
+    {
+        if (name == "AABB")                           return Renderer_Option::Aabb;
+        else if (name == "Picking Ray")               return Renderer_Option::PickingRay;
+        else if (name == "Grid")                      return Renderer_Option::Grid;
+        else if (name == "Transform Handle")          return Renderer_Option::TransformHandle;
+        else if (name == "Selection Outline")         return Renderer_Option::SelectionOutline;
+        else if (name == "Lights")                    return Renderer_Option::Lights;
+        else if (name == "Audio Sources")             return Renderer_Option::AudioSources;
+        else if (name == "Performance Metrics")       return Renderer_Option::PerformanceMetrics;
+        else if (name == "Physics")                   return Renderer_Option::Physics;
+        else if (name == "Wireframe")                 return Renderer_Option::Wireframe;
+        else if (name == "Bloom")                     return Renderer_Option::Bloom;
+        else if (name == "Fog")                       return Renderer_Option::Fog;
+        else if (name == "Ambient Occlusion (SSAO)")  return Renderer_Option::ScreenSpaceAmbientOcclusion;
+        else if (name == "Reflections (SSR)")         return Renderer_Option::ScreenSpaceReflections;
+        else if (name == "Reflections (Ray Traced)")  return Renderer_Option::RayTracedReflections;
+        else if (name == "Motion Blur")               return Renderer_Option::MotionBlur;
+        else if (name == "Depth Of Field")            return Renderer_Option::DepthOfField;
+        else if (name == "Film Grain")                return Renderer_Option::FilmGrain;
+        else if (name == "VHS Effect")                return Renderer_Option::Vhs;
+        else if (name == "Chromatic Aberration")      return Renderer_Option::ChromaticAberration;
+        else if (name == "Anisotropy")                return Renderer_Option::Anisotropy;
+        else if (name == "Tone Mapping")              return Renderer_Option::Tonemapping;
+        else if (name == "Anti-Aliasing Upsampling")  return Renderer_Option::AntiAliasing_Upsampling;
+        else if (name == "Sharpness")                 return Renderer_Option::Sharpness;
+        else if (name == "Dithering")                 return Renderer_Option::Dithering;
+        else if (name == "HDR")                       return Renderer_Option::Hdr;
+        else if (name == "White Point")               return Renderer_Option::WhitePoint;
+        else if (name == "Gamma")                     return Renderer_Option::Gamma;
+        else if (name == "VSync")                     return Renderer_Option::Vsync;
+        else if (name == "Variable Rate Shading")     return Renderer_Option::VariableRateShading;
+        else if (name == "Resolution Scale")          return Renderer_Option::ResolutionScale;
+        else if (name == "Dynamic Resolution")        return Renderer_Option::DynamicResolution;
+        else if (name == "Occlusion Culling")         return Renderer_Option::OcclusionCulling;
+        else if (name == "Exposure Adaptation Speed") return Renderer_Option::AutoExposureAdaptationSpeed;
+        else                                          return Renderer_Option::Max; // Default fallback
+    }
+}

--- a/source/runtime/Rendering/RenderOptionsPool.h
+++ b/source/runtime/Rendering/RenderOptionsPool.h
@@ -1,0 +1,155 @@
+﻿/*
+Copyright(c) 2015-2025 Panos Karabelas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+//= INCLUDES =================================
+#include "Renderer_Definitions.h"
+//============================================
+
+namespace spartan
+{
+    template<typename E>
+    constexpr auto enum_range()
+    {
+        return std::pair{E{0}, E::MAX};
+    }
+
+    template <typename T>
+    struct hash
+    {
+        std::enable_if_t<std::is_enum_v<T>, std::size_t>
+        operator()(T t) const noexcept
+        {
+            return static_cast<std::size_t>(t);
+        }
+    };
+
+    enum class RenderOptionsListType : uint32_t
+    {
+        Global,
+        Override
+    };
+
+    /*
+     * A class that encompasses all the rendering options settings.
+     * Option settings can be a mix of different global rendering properties
+     * or component related data, which include post-process, camera, world,
+     * weather, output, debugging and more.
+     * This is a scalable system that can work for different parameter collection
+     * methods.
+     */
+    class RenderOptionsPool
+    {
+    private:
+        std::map<Renderer_Option, RenderOptionType> m_options;
+    public:
+        RenderOptionsPool();
+        RenderOptionsPool(const RenderOptionsListType list_type);
+        RenderOptionsPool(const std::map<Renderer_Option, RenderOptionType>& options);
+        RenderOptionsPool(RenderOptionsPool& other); // Move version
+        ~RenderOptionsPool() = default;
+
+        // Options map
+        std::map<Renderer_Option, RenderOptionType> GetOptions() const { return m_options;}
+        void SetOptions(const std::map<Renderer_Option, RenderOptionType>& options) { m_options = options; }
+
+        bool operator!=(const RenderOptionsPool& other) const;
+
+        static std::string EnumToString(Renderer_Option option); // used most likely for editor-related applications
+        static Renderer_Option StringToEnum(const std::string& name);
+
+        void SetOption(Renderer_Option option, const RenderOptionType& value);
+
+        RenderOptionType GetOption(const Renderer_Option option) const { return m_options.at(option); }
+
+        // Getters in the form of templates
+        template<typename T>
+        T GetOption(Renderer_Option option)
+        {
+            auto it = m_options.find(option);
+            if (it == m_options.end())
+            {
+                return T{}; // default fallback for specific value type
+            }
+
+            auto& variant_value = it->second;
+
+            if constexpr (std::is_enum_v<T>) // T is an enum: cast
+            {
+                return std::holds_alternative<uint32_t>(variant_value) ? static_cast<T>(std::get<uint32_t>(variant_value)) : T{};
+            }
+            else // T is bool, int, float
+            {
+                return std::holds_alternative<T>(variant_value) ? std::get<T>(variant_value) : T{};
+            }
+        }
+        template<typename T>
+        T& GetOptionRef(Renderer_Option option)
+        {
+            auto it = m_options.find(option);
+            if (it == m_options.end())
+            {
+                throw std::out_of_range("Option not found");
+            }
+
+            auto& variant_value = it->second;
+
+            if constexpr (!std::is_enum_v<T>) // bool, int, float
+            {
+                return std::get<T>(variant_value);
+            }
+            else
+            {
+                static T dummy{}; // fallback for enums (can't reference the cast)
+                return dummy;     // or throw / handle separately
+            }
+        }
+
+        template<typename... Ts>
+        static bool AreVariantsEqual(const std::variant<Ts...>& a, const std::variant<Ts...>& b)
+        {
+            // Fast path: if the active types differ, they cannot be equal
+            if (a.index() != b.index())
+                return false;
+
+            // Compare only if they hold the same type
+            return std::visit([]<typename T0, typename T1>(T0&& lhs, T1&& rhs) -> bool
+            {
+                using T = std::decay_t<T0>;
+
+                // Check that both are the same type at compile time
+                if constexpr (std::is_same_v<T, std::decay_t<T1>>)
+                {
+                    // For floats, use epsilon comparison to avoid precision errors
+                    if constexpr (std::is_floating_point_v<T>)
+                        return std::fabs(lhs - rhs) < 1e-6f;
+                    else
+                        return lhs == rhs;
+                }
+                else
+                {
+                    return false; // Different types — not equal
+                }
+            }, a, b);
+        }
+    };
+}

--- a/source/runtime/Rendering/Renderer.h
+++ b/source/runtime/Rendering/Renderer.h
@@ -31,6 +31,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../Font/Font.h"
 #include <unordered_map>
 #include <atomic>
+#include "RenderOptionsPool.h"
 #include "../Math/Rectangle.h"
 //===============================
 
@@ -74,12 +75,14 @@ namespace spartan
         static void DrawString(const char* text, const math::Vector2& position_screen_percentage);
         static void DrawIcon(RHI_Texture* icon, const math::Vector2& position_screen_percentage);
 
-        // options
-        template<typename T>
-        static T GetOption(const Renderer_Option option) { return static_cast<T>(GetOptions()[option]); }
-        static void SetOption(Renderer_Option option, float value);
-        static std::unordered_map<Renderer_Option, float>& GetOptions();
-        static void SetOptions(const std::unordered_map<Renderer_Option, float>& options);
+        // render options
+        static RenderOptionType GetOption(const Renderer_Option option, bool bIsEditor = false) { return bIsEditor ? editor_options.GetOption(option) : global_options.GetOption(option); }
+        template<typename T> static T GetOption(Renderer_Option option, bool bIsEditor = false) { return bIsEditor ? editor_options.GetOption<T>(option) : global_options.GetOption<T>(option); }
+        template<typename T> static T& GetOptionRef(Renderer_Option option, bool bIsEditor = false) { return bIsEditor ? editor_options.GetOptionRef<T>(option) : global_options.GetOptionRef<T>(option); }
+        static void SetOption(Renderer_Option option, const RenderOptionType& value, bool bIsEditor = false) { return bIsEditor ? editor_options.SetOption(option, value) : global_options.SetOption(option, value); }
+        static RenderOptionsPool GetRenderOptionsPool(bool bIsEditor = false) { return bIsEditor ? editor_options : global_options; }
+        static RenderOptionsPool& GetRenderOptionsPoolRef(bool bIsEditor = false) { return bIsEditor ? editor_options : global_options; }
+        static void SetOverrideOptions(bool is_overridden) { is_override_options = is_overridden; }
 
         // swapchain
         static RHI_SwapChain* GetSwapChain();
@@ -203,6 +206,7 @@ namespace spartan
         static void UpdateShadowAtlas();
         static void UpdateDrawCalls(RHI_CommandList* cmd_list);
         static void UpdateAccelerationStructures(RHI_CommandList* cmd_list);
+        static void ApplyRenderOptions();
 
         // draw calls
         static std::array<Renderer_DrawCall, renderer_max_draw_calls> m_draw_calls;
@@ -217,6 +221,9 @@ namespace spartan
         static bool m_bindless_samplers_dirty;
 
         // misc
+        static RenderOptionsPool global_options;
+        static RenderOptionsPool editor_options;
+        static bool is_override_options;
         static Cb_Frame m_cb_frame_cpu;
         static Pcb_Pass m_pcb_pass_cpu;
         static std::shared_ptr<RHI_Buffer> m_lines_vertex_buffer;

--- a/source/runtime/Rendering/Renderer_Definitions.h
+++ b/source/runtime/Rendering/Renderer_Definitions.h
@@ -31,6 +31,8 @@ namespace spartan
     const uint32_t renderer_max_draw_calls          = 20000;
     const uint32_t renderer_max_instance_count      = 1024;
 
+    using RenderOptionType = std::variant<bool, int, float, uint32_t>;
+
     enum class Renderer_Option : uint32_t
     {
         Aabb,

--- a/source/runtime/World/Components/Component.cpp
+++ b/source/runtime/World/Components/Component.cpp
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "Camera.h"
 #include "AudioSource.h"
 #include "Terrain.h"
+#include "Volume.h"
 //======================
 
 //= NAMESPACES =====
@@ -56,4 +57,5 @@ namespace spartan
     REGISTER_COMPONENT(Renderable,  ComponentType::Renderable)
     REGISTER_COMPONENT(Physics,     ComponentType::Physics)
     REGISTER_COMPONENT(Terrain,     ComponentType::Terrain)
+    REGISTER_COMPONENT(Volume,      ComponentType::Volume)
 }

--- a/source/runtime/World/Components/Component.h
+++ b/source/runtime/World/Components/Component.h
@@ -46,6 +46,7 @@ namespace spartan
         Physics,
         Renderable,
         Terrain,
+        Volume,
         Max
     };
     // after re-ordering the above, ensure .world save/load works
@@ -113,7 +114,8 @@ namespace spartan
             if (name == "physics")      return ComponentType::Physics;
             if (name == "renderable")   return ComponentType::Renderable;
             if (name == "terrain")      return ComponentType::Terrain;
-        
+            if (name == "volume")       return ComponentType::Volume;
+
             assert(false && "StringToType: Unknown component name");
             return ComponentType::Max;
         }

--- a/source/runtime/World/Components/Volume.cpp
+++ b/source/runtime/World/Components/Volume.cpp
@@ -1,0 +1,250 @@
+﻿/*
+Copyright(c) 2015-2025 Panos Karabelas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+//= INCLUDES =================================
+#include "pch.h"
+#include "Rendering/Renderer.h"
+#include "Volume.h"
+
+#include <algorithm>
+
+#include "Camera.h"
+#include "IO/pugixml.hpp"
+#include "World/Entity.h"
+//============================================
+
+//= NAMESPACES ===============
+using namespace std;
+using namespace spartan::math;
+//============================
+
+namespace spartan
+{
+    RenderOptionsPool Volume::blended_options = RenderOptionsPool(RenderOptionsListType::Global);; // volume data accumulation (on interpolation)
+    map<Renderer_Option, float> Volume::accumulator_floats {};
+    map<Renderer_Option, float> Volume::accumulator_weights {};
+    int Volume::overlapping_count = 0;
+    uint64_t Volume::accumulation_frame = UINT64_MAX;
+    uint64_t Volume::finalization_frame = UINT64_MAX;
+
+    Volume::Volume(Entity* entity) : Component(entity)
+    {
+        SP_REGISTER_ATTRIBUTE_VALUE_VALUE(m_volume_shape_type, VolumeType);
+        SP_REGISTER_ATTRIBUTE_VALUE_VALUE(m_shape_size, float);
+        SP_REGISTER_ATTRIBUTE_VALUE_VALUE(m_transition_size, float);
+        SP_REGISTER_ATTRIBUTE_VALUE_VALUE(m_is_debug_draw_enabled, bool);
+
+        m_volume_shape_type = VolumeType::Sphere;
+        m_bounding_box = BoundingBox::Unit;
+        m_shape_size = default_shape_size;
+        m_transition_size = default_transition_size;
+        m_is_debug_draw_enabled = true;
+
+        m_options_pool = RenderOptionsPool(RenderOptionsListType::Override);
+    }
+
+    Volume::~Volume()
+    {
+
+    }
+
+    void Volume::Save(pugi::xml_node& node)
+    {
+        node.append_attribute("shape_type")      = static_cast<int>(m_volume_shape_type);
+        node.append_attribute("shape_size")      = m_shape_size;
+        node.append_attribute("transition_size") = m_transition_size;
+        node.append_attribute("debug_enabled")   = m_is_debug_draw_enabled;
+    }
+
+    void Volume::Load(pugi::xml_node& node)
+    {
+        m_volume_shape_type = static_cast<VolumeType>(node.attribute("shape_type").as_int(static_cast<int>(VolumeType::Max)));
+        m_shape_size = node.attribute("shape_size").as_float();
+        m_transition_size = node.attribute("transition_size").as_float();
+        m_is_debug_draw_enabled = node.attribute("debug_enabled").as_bool();
+
+        m_bounding_box = BoundingBox::Unit;
+        m_options_pool = RenderOptionsPool(RenderOptionsListType::Override);
+    }
+
+    void Volume::PreTick()
+    {
+        const uint64_t frame = Renderer::GetFrameNumber();
+
+        // Reset data only once per frame
+        if (accumulation_frame != frame)
+        {
+            accumulation_frame = frame;
+            accumulator_floats.clear();
+            accumulator_weights.clear();
+            blended_options = Renderer::GetRenderOptionsPoolRef(true);
+            overlapping_count = 0;
+        }
+
+        const Camera* camera = World::GetCamera();
+        if (!camera)
+            return;
+
+        const Vector3 cam_position = camera->GetEntity()->GetPosition();
+        const float alpha = ComputeAlpha(cam_position);
+
+        const bool is_overlapping_now = alpha > 0.0f;
+
+        // Override Renderer only when necessary (when the camera has entered at least one volume)
+        if (is_overlapping_now)
+        {
+            ++overlapping_count;
+            Renderer::SetOverrideOptions(true);
+        }
+
+        if (!is_overlapping_now)
+            return;
+
+        AccumulateRenderOptions(alpha);
+    }
+
+    void Volume::Tick()
+    {
+        if (m_is_debug_draw_enabled)
+        {
+            DrawVolume();
+        }
+
+        const uint64_t frame = Renderer::GetFrameNumber();
+
+        // Finalize and apply data only once per frame
+        if (finalization_frame == frame)
+            return;
+
+        finalization_frame = frame;
+
+        if (overlapping_count == 0)
+        {
+            Renderer::SetOverrideOptions(false);
+            return;
+        }
+
+        ApplyRenderOptions();
+    }
+
+    void Volume::AccumulateRenderOptions(const float alpha)
+    {
+        for (auto& [key, value] : m_options_pool.GetOptions())
+        {
+            if (std::holds_alternative<float>(value))
+            {
+                const float v = std::get<float>(value);
+                accumulator_floats[key]  += v * alpha;
+                accumulator_weights[key] += alpha;
+            }
+            else
+            {
+                blended_options.SetOption(key, value);
+            }
+        }
+    }
+
+    void Volume::ApplyRenderOptions()
+    {
+        for (auto& [key, sum] : accumulator_floats)
+        {
+            const float weight = accumulator_weights[key];
+            if (weight <= 0.0f)
+                continue;
+
+            const float float_average = sum / weight;
+            const float global_float_option = Renderer::GetRenderOptionsPoolRef(true).GetOption<float>(key);
+            const float t = clamp(weight, 0.0f, 1.0f);
+
+            blended_options.SetOption(key, lerp(global_float_option, float_average, t));
+        }
+
+        // Apply to renderer only if values have changed
+        for (auto& [key, value] : blended_options.GetOptions())
+        {
+            if (!RenderOptionsPool::AreVariantsEqual(Renderer::GetOption(key), value))
+            {
+                Renderer::SetOption(key, value);
+            }
+        }
+    }
+
+    void Volume::DrawVolume()
+    {
+        // For debugging
+        if (m_volume_shape_type == VolumeType::Sphere)
+        {
+            Renderer::DrawSphere(m_entity_ptr->GetPosition(), m_shape_size, 16, Color::standard_yellow);
+            Renderer::DrawSphere(m_entity_ptr->GetPosition(), m_shape_size + m_transition_size, 16, Color::standard_renderer_lines);
+        }
+        else if (m_volume_shape_type == VolumeType::Box)
+        {
+            const Matrix new_matrix_inner = Matrix(m_entity_ptr->GetPosition(), m_entity_ptr->GetRotation(), m_entity_ptr->GetScale() + m_shape_size);
+            Renderer::DrawBox(m_bounding_box * new_matrix_inner, Color::standard_yellow);
+
+            const Matrix new_matrix_outer = Matrix(m_entity_ptr->GetPosition(), m_entity_ptr->GetRotation(), m_entity_ptr->GetScale() + m_shape_size + m_transition_size);
+            Renderer::DrawBox(m_bounding_box * new_matrix_outer, Color::standard_renderer_lines);
+        }
+    }
+
+    float Volume::ComputeAlpha(const Vector3& camera_position) const
+    {
+        if (m_volume_shape_type == VolumeType::Box)
+        {
+            const Vector3 distance_absolute = (camera_position - m_entity_ptr->GetPosition()).Abs();
+
+            const Vector3 inner_half_extents = m_bounding_box.GetExtents() + Vector3(m_shape_size / 2.0f);
+            const Vector3 outer_half_extents = inner_half_extents + Vector3(m_transition_size);
+
+            const float dist_to_inner = (distance_absolute - inner_half_extents).Max(Vector3::Zero).Length();
+            const float dist_to_outer = (distance_absolute - outer_half_extents).Max(Vector3::Zero).Length();
+
+            if (dist_to_inner <= 0.0f)
+            {
+                return 1.0f;
+            }
+            if (dist_to_outer > 0.0f)
+            {
+                return 0.0f;
+            }
+
+            return 1.0f - dist_to_inner / m_transition_size;
+        }
+        if (m_volume_shape_type == VolumeType::Sphere)
+        {
+            const float distance = Vector3::Distance(camera_position, m_entity_ptr->GetPosition());
+
+            if (distance > m_transition_size + m_shape_size)
+            {
+                return 0.0f;
+            }
+            if (distance <= m_shape_size)
+            {
+                return 1.0f;
+            }
+
+            return 1.0f - (distance - m_shape_size) / m_transition_size;
+        }
+
+        // Unknown shape. Reset to hard transition.
+        return 1.0f;
+    }
+}

--- a/source/runtime/World/Components/Volume.h
+++ b/source/runtime/World/Components/Volume.h
@@ -1,0 +1,105 @@
+﻿/*
+Copyright(c) 2015-2025 Panos Karabelas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+//= INCLUDES =================================
+#include "Component.h"
+#include "Rendering/RenderOptionsPool.h"
+//============================================
+
+namespace spartan
+{
+    static constexpr float default_shape_size = 1.0f;
+    static constexpr float default_transition_size = 0.2f;
+
+    enum class VolumeType
+    {
+        Box,
+        Sphere,
+        Max
+    };
+
+    /*
+     * A component that handles local overrides of global components.
+     * A volume contains a map of each component with a list of its registered attributes.
+     * Static data help with managing and accumulating data from multiple volumes at once
+     * and avoid repeated actions per frame.
+     */
+    class Volume : public Component
+    {
+    private:
+        //===== STATIC DATA FOR VOLUME MANAGEMENT =====
+        static RenderOptionsPool blended_options; // volume data accumulation (on interpolation)
+        static std::map<Renderer_Option, float> accumulator_floats;
+        static std::map<Renderer_Option, float> accumulator_weights;
+        static int overlapping_count;
+        static uint64_t accumulation_frame;
+        static uint64_t finalization_frame;
+        //=============================================
+
+        VolumeType m_volume_shape_type   = VolumeType::Sphere;
+        float m_shape_size               = default_shape_size;
+        float m_transition_size          = default_transition_size;
+        bool m_is_debug_draw_enabled     = true;
+
+        math::BoundingBox m_bounding_box = math::BoundingBox::Unit;
+
+        RenderOptionsPool m_options_pool = RenderOptionsPool(RenderOptionsListType::Override);
+
+        void AccumulateRenderOptions(float alpha);
+        static void ApplyRenderOptions();
+
+        void DrawVolume();
+    public:
+        Volume(Entity* entity);
+        ~Volume() override;
+
+        //= COMPONENT ================================
+        void PreTick() override;
+        void Tick() override;
+        void Save(pugi::xml_node& node) override;
+        void Load(pugi::xml_node& node) override;
+        //============================================
+
+        float ComputeAlpha(const math::Vector3& camera_position) const;
+
+        // Render Options Collection
+        RenderOptionsPool& GetOptionsCollection() { return m_options_pool; }
+        void SetOptionsCollection(const RenderOptionsPool& options_collection) { m_options_pool = options_collection; }
+
+        // Mesh Type
+        VolumeType GetVolumeShapeType() const { return m_volume_shape_type; }
+        void SetMeshType(const VolumeType volume_type) { m_volume_shape_type = volume_type; }
+
+        // Shape size
+        float GetShapeSize() const { return m_shape_size; }
+        void SetShapeSize(const float shape_size) { m_shape_size = shape_size; }
+
+        // Transition size
+        float GetTransitionSize() const { return m_transition_size; }
+        void SetTransitionSize(const float transition_size) { m_transition_size = transition_size; }
+
+        // Debug Draw
+        bool GetDebugDrawEnabled() const { return m_is_debug_draw_enabled; }
+        void SetDebugDrawEnabled(bool value) { m_is_debug_draw_enabled = value; }
+    };
+}


### PR DESCRIPTION
**Volume component** is now ready to implemented on Spartan Engine!

Link to original issue: https://github.com/PanosK92/SpartanEngine/issues/147

The purpose of this component is to locally override global render options when walking inside a volume's shape. The applications of this feature are endless and it can assist in having varying effects, lighting, weather and ambiance within a scene.

Here is the Volume component in action:
https://github.com/user-attachments/assets/d1794f63-980c-4754-89f4-8d428944b72d
I placed a box volume with an override fog intensity value of 100.0 from 1.0 the default (global) value.

What should you expect from this PR:

- [x] A Volume class that blends the global render options from the renderer when there is **one or multiple volumes in the scene**.
- [x] When a volume is active, it turns an override switch on, temporarily breaking the direct assignment from Editor widgets to the Renderer. It's just a bool really.
- [x] **Completely self-contained volume system** (including managing multiple volumes). If removed, original system will function as before. Code changes have been kept to a minimum.
- [x] RenderOptionsPool class that stores the render options instead of being directly implemented in the Renderer. This was necessary for the Volume to have access to the render options and basically interpolate through them. This also removed a lot of unnecessary code from the Renderer and placed it on its own file. **I can submit this as a separate PR before submitting the volume component code?**
- [x] Separated Editor and Renderer options columns in editor menu and in code. This helps with seeing the render value that is currently active when overridden.
- [x] Some extra IMGUI widget items to handle more types and behaviours (slider floats, third columns, etc).

Future plans? Depends on the demand and interests:
- More render options from other features. Easier now with the new class! (ex: volumetric clouds)
- Override other component properties in scene (ex; directional light)
- Separate volume size scaling in all 3 axes instead of resizing it as a whole
- Time-based interpolation instead of just distance-based
- Curved interpolations instead of just linear
- More volume shapes?

I'm always open for suggestions and improvements.