### PR TITLE
Render Options Pool

### DIFF
--- a/source/runtime/Game/Game.cpp
+++ b/source/runtime/Game/Game.cpp
@@ -290,10 +290,10 @@ namespace spartan
         void set_base_renderer_options()
          {
              // disable all effects which are specific to certain worlds, let the each world decide which effects it wants to enable
-             Renderer::SetOption(Renderer_Option::Dithering,           0.0f);
-             Renderer::SetOption(Renderer_Option::ChromaticAberration, 0.0f);
-             Renderer::SetOption(Renderer_Option::Grid,                0.0f);
-             Renderer::SetOption(Renderer_Option::Vhs,                 0.0f);
+             Renderer::SetOption(Renderer_Option::Dithering,           false);
+             Renderer::SetOption(Renderer_Option::ChromaticAberration, false);
+             Renderer::SetOption(Renderer_Option::Grid,                false);
+             Renderer::SetOption(Renderer_Option::Vhs,                 false);
          }
     }
 
@@ -1344,9 +1344,9 @@ namespace spartan
 
                 // adjust renderer options
                 {
-                    Renderer::SetOption(Renderer_Option::PerformanceMetrics, 0.0f);
-                    Renderer::SetOption(Renderer_Option::Lights,             0.0f);
-                    Renderer::SetOption(Renderer_Option::Dithering,          0.0f);
+                    Renderer::SetOption(Renderer_Option::PerformanceMetrics, false);
+                    Renderer::SetOption(Renderer_Option::Lights,             false);
+                    Renderer::SetOption(Renderer_Option::Dithering,          false);
                 }
             }
 
@@ -1460,8 +1460,8 @@ namespace spartan
                 }
             
                 // renderer options
-                Renderer::SetOption(Renderer_Option::ChromaticAberration, 1.0f);
-                Renderer::SetOption(Renderer_Option::Vhs, 1.0f);
+                Renderer::SetOption(Renderer_Option::ChromaticAberration, true);
+                Renderer::SetOption(Renderer_Option::Vhs, true);
             
                 // camera
                 entities::camera(Vector3(5.4084f, 1.8f, 4.7593f));

--- a/source/runtime/Rendering/RenderOptionsPool.cpp
+++ b/source/runtime/Rendering/RenderOptionsPool.cpp
@@ -1,0 +1,262 @@
+﻿/*
+Copyright(c) 2015-2025 Panos Karabelas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+//= INCLUDES =================================
+#include "pch.h"
+#include "RenderOptionsPool.h"
+//============================================
+
+#include "Display/Display.h"
+#include "Profiling/Profiler.h"
+#include "Rendering/Renderer.h"
+#include "RHI/RHI_Device.h"
+#include "RHI/RHI_SwapChain.h"
+#include "RHI/RHI_VendorTechnology.h"
+//============================================
+
+//= NAMESPACES ===============
+using namespace std;
+using namespace spartan::math;
+//============================
+
+namespace spartan
+{
+    RenderOptionsPool::RenderOptionsPool()
+    {
+        m_options.clear();
+        m_options[Renderer_Option::WhitePoint] =                  350.0f; // float
+        m_options[Renderer_Option::Tonemapping] =                 static_cast<uint32_t>(Renderer_Tonemapping::Max); // enum
+        m_options[Renderer_Option::Bloom] =                       1.0f;  // non-zero values activate it and control the intensity, float
+        m_options[Renderer_Option::MotionBlur] =                  true;  // bool
+        m_options[Renderer_Option::DepthOfField] =                true;  // bool
+        m_options[Renderer_Option::FilmGrain] =                   false; // bool
+        m_options[Renderer_Option::ChromaticAberration] =         false; // bool
+        m_options[Renderer_Option::Vhs] =                         false; // bool
+        m_options[Renderer_Option::Dithering] =                   false; // bool
+        m_options[Renderer_Option::ScreenSpaceAmbientOcclusion] = true;  // bool
+        m_options[Renderer_Option::ScreenSpaceReflections] =      true;  // bool
+        m_options[Renderer_Option::RayTracedReflections] =        RHI_Device::IsSupportedRayTracing(); // bool
+        m_options[Renderer_Option::Fog] =                         1.0f;  // float
+        m_options[Renderer_Option::VariableRateShading] =         false; // bool
+        m_options[Renderer_Option::Vsync] =                       false; // bool
+        m_options[Renderer_Option::TransformHandle] =             true;  // bool
+        m_options[Renderer_Option::SelectionOutline] =            false; // bool
+        m_options[Renderer_Option::Grid] =                        false; // bool
+        m_options[Renderer_Option::Lights] =                      true;  // bool
+        m_options[Renderer_Option::AudioSources] =                true;  // bool
+        m_options[Renderer_Option::Physics] =                     false; // bool
+        m_options[Renderer_Option::PerformanceMetrics] =          true;  // bool
+        m_options[Renderer_Option::Gamma] =                       Display::GetGamma(); // float
+        m_options[Renderer_Option::Hdr] =                         false; // bool
+        m_options[Renderer_Option::AutoExposureAdaptationSpeed] = 0.5f;  // float
+        m_options[Renderer_Option::Aabb] =                        false; // bool
+        m_options[Renderer_Option::PickingRay] =                  false; // bool
+        m_options[Renderer_Option::Wireframe] =                   false; // bool
+        m_options[Renderer_Option::Anisotropy] =                  16.0f; // float
+        m_options[Renderer_Option::Sharpness] =                   1.0f;  // float
+        m_options[Renderer_Option::AntiAliasing_Upsampling] =     static_cast<uint32_t>(Renderer_AntiAliasing_Upsampling::AA_Fsr_Upscale_Fsr); // enum
+        m_options[Renderer_Option::ResolutionScale] =             1.0f;  // float
+        m_options[Renderer_Option::DynamicResolution] =           false; // bool
+        m_options[Renderer_Option::OcclusionCulling] =            false; // bool
+    }
+
+    RenderOptionsPool::RenderOptionsPool(const std::map<Renderer_Option, RenderOptionType>& options)
+    {
+        m_options.clear();
+        m_options = options;
+    }
+
+    RenderOptionsPool::RenderOptionsPool(RenderOptionsPool& other)
+    {
+        m_options.clear();
+        for (const auto& [key, value] : other.m_options)
+        {
+            m_options[key] = value; // replaces if key exists, inserts otherwise
+        }
+    }
+
+    void RenderOptionsPool::SetOption(Renderer_Option option, const RenderOptionType& value)
+    {
+        // Handle clamping for float options
+        if (std::holds_alternative<float>(value))
+        {
+            float v = std::get<float>(value);
+
+            if (option == Renderer_Option::Anisotropy)
+            {
+                v = clamp(v, 0.0f, 16.0f);
+            }
+            else if (option == Renderer_Option::ResolutionScale)
+            {
+                v = clamp(v, 0.5f, 1.0f);
+            }
+
+            // HDR, VRS, etc. validation (float enums)
+            if (option == Renderer_Option::Hdr && v == 1.0f && !Display::GetHdr())
+            {
+                SP_LOG_WARNING("This display doesn't support HDR");
+                return;
+            }
+            else if (option == Renderer_Option::VariableRateShading && v == 1.0f && !RHI_Device::IsSupportedVrs())
+            {
+                SP_LOG_WARNING("This GPU doesn't support variable rate shading");
+                return;
+            }
+
+            m_options[option] = v;
+        }
+        else if (std::holds_alternative<bool>(value))
+        {
+            bool v = std::get<bool>(value);
+
+            m_options[option] = v;
+
+            // cascade for toggles
+            if (option == Renderer_Option::Vsync && Renderer::GetSwapChain())
+            {
+                Renderer::GetSwapChain()->SetVsync(v);
+            }
+            else if (option == Renderer_Option::PerformanceMetrics)
+            {
+                static bool enabled = false;
+                if (!enabled && v)
+                    Profiler::ClearMetrics();
+                enabled = v;
+            }
+        }
+        else if (std::holds_alternative<uint32_t>(value))
+        {
+            uint32_t v = std::get<uint32_t>(value);
+            m_options[option] = v;
+        }
+        else if (std::holds_alternative<int>(value))
+        {
+            int v = std::get<int>(value);
+            m_options[option] = v;
+        }
+
+        // ---- Cascading logic after setting ----
+        if (std::holds_alternative<float>(value))
+        {
+            float v = std::get<float>(value);
+
+            if (option == Renderer_Option::AntiAliasing_Upsampling)
+            {
+                if (v == static_cast<float>(Renderer_AntiAliasing_Upsampling::AA_Fsr_Upscale_Fsr) ||
+                    v == static_cast<float>(Renderer_AntiAliasing_Upsampling::AA_Xess_Upscale_Xess))
+                {
+                    RHI_VendorTechnology::ResetHistory();
+                }
+            }
+            else if (option == Renderer_Option::Hdr && Renderer::GetSwapChain())
+            {
+                Renderer::GetSwapChain()->SetHdr(v == 1.0f);
+            }
+        }
+    }
+
+    bool RenderOptionsPool::operator!=(const RenderOptionsPool& other) const
+    {
+        return m_options != other.m_options;
+    }
+
+    // For Editor
+    std::string RenderOptionsPool::EnumToString(Renderer_Option option)
+    {
+        switch (option)
+        {
+            case Renderer_Option::Aabb:                        return "AABB";
+            case Renderer_Option::PickingRay:                  return "Picking Ray";
+            case Renderer_Option::Grid:                        return "Grid";
+            case Renderer_Option::TransformHandle:             return "Transform Handle";
+            case Renderer_Option::SelectionOutline:            return "Selection Outline";
+            case Renderer_Option::Lights:                      return "Lights";
+            case Renderer_Option::AudioSources:                return "Audio Sources";
+            case Renderer_Option::PerformanceMetrics:          return "Performance Metrics";
+            case Renderer_Option::Physics:                     return "Physics";
+            case Renderer_Option::Wireframe:                   return "Wireframe";
+            case Renderer_Option::Bloom:                       return "Bloom";
+            case Renderer_Option::Fog:                         return "Fog";
+            case Renderer_Option::ScreenSpaceAmbientOcclusion: return "Ambient Occlusion (SSAO)";
+            case Renderer_Option::ScreenSpaceReflections:      return "Reflections (SSR)";
+            case Renderer_Option::RayTracedReflections:        return "Reflections (Ray Traced)";
+            case Renderer_Option::MotionBlur:                  return "Motion Blur";
+            case Renderer_Option::DepthOfField:                return "Depth Of Field";
+            case Renderer_Option::FilmGrain:                   return "Film Grain";
+            case Renderer_Option::Vhs:                         return "VHS Effect";
+            case Renderer_Option::ChromaticAberration:         return "Chromatic Aberration";
+            case Renderer_Option::Anisotropy:                  return "Anisotropy";
+            case Renderer_Option::Tonemapping:                 return "Tone Mapping";
+            case Renderer_Option::AntiAliasing_Upsampling:     return "Anti-Aliasing Upsampling";
+            case Renderer_Option::Sharpness:                   return "Sharpness";
+            case Renderer_Option::Dithering:                   return "Dithering";
+            case Renderer_Option::Hdr:                         return "HDR";
+            case Renderer_Option::WhitePoint:                  return "White Point";
+            case Renderer_Option::Gamma:                       return "Gamma";
+            case Renderer_Option::Vsync:                       return "VSync";
+            case Renderer_Option::VariableRateShading:         return "Variable Rate Shading";
+            case Renderer_Option::ResolutionScale:             return "Resolution Scale";
+            case Renderer_Option::DynamicResolution:           return "Dynamic Resolution";
+            case Renderer_Option::OcclusionCulling:            return "Occlusion Culling";
+            case Renderer_Option::AutoExposureAdaptationSpeed: return "Exposure Adaptation Speed";
+            default:                                           return "Max";
+        }
+    }
+
+    Renderer_Option RenderOptionsPool::StringToEnum(const std::string& name)
+    {
+        if (name == "AABB")                           return Renderer_Option::Aabb;
+        else if (name == "Picking Ray")               return Renderer_Option::PickingRay;
+        else if (name == "Grid")                      return Renderer_Option::Grid;
+        else if (name == "Transform Handle")          return Renderer_Option::TransformHandle;
+        else if (name == "Selection Outline")         return Renderer_Option::SelectionOutline;
+        else if (name == "Lights")                    return Renderer_Option::Lights;
+        else if (name == "Audio Sources")             return Renderer_Option::AudioSources;
+        else if (name == "Performance Metrics")       return Renderer_Option::PerformanceMetrics;
+        else if (name == "Physics")                   return Renderer_Option::Physics;
+        else if (name == "Wireframe")                 return Renderer_Option::Wireframe;
+        else if (name == "Bloom")                     return Renderer_Option::Bloom;
+        else if (name == "Fog")                       return Renderer_Option::Fog;
+        else if (name == "Ambient Occlusion (SSAO)")  return Renderer_Option::ScreenSpaceAmbientOcclusion;
+        else if (name == "Reflections (SSR)")         return Renderer_Option::ScreenSpaceReflections;
+        else if (name == "Reflections (Ray Traced)")  return Renderer_Option::RayTracedReflections;
+        else if (name == "Motion Blur")               return Renderer_Option::MotionBlur;
+        else if (name == "Depth Of Field")            return Renderer_Option::DepthOfField;
+        else if (name == "Film Grain")                return Renderer_Option::FilmGrain;
+        else if (name == "VHS Effect")                return Renderer_Option::Vhs;
+        else if (name == "Chromatic Aberration")      return Renderer_Option::ChromaticAberration;
+        else if (name == "Anisotropy")                return Renderer_Option::Anisotropy;
+        else if (name == "Tone Mapping")              return Renderer_Option::Tonemapping;
+        else if (name == "Anti-Aliasing Upsampling")  return Renderer_Option::AntiAliasing_Upsampling;
+        else if (name == "Sharpness")                 return Renderer_Option::Sharpness;
+        else if (name == "Dithering")                 return Renderer_Option::Dithering;
+        else if (name == "HDR")                       return Renderer_Option::Hdr;
+        else if (name == "White Point")               return Renderer_Option::WhitePoint;
+        else if (name == "Gamma")                     return Renderer_Option::Gamma;
+        else if (name == "VSync")                     return Renderer_Option::Vsync;
+        else if (name == "Variable Rate Shading")     return Renderer_Option::VariableRateShading;
+        else if (name == "Resolution Scale")          return Renderer_Option::ResolutionScale;
+        else if (name == "Dynamic Resolution")        return Renderer_Option::DynamicResolution;
+        else if (name == "Occlusion Culling")         return Renderer_Option::OcclusionCulling;
+        else if (name == "Exposure Adaptation Speed") return Renderer_Option::AutoExposureAdaptationSpeed;
+        else                                          return Renderer_Option::Max; // Default fallback
+    }
+}

--- a/source/runtime/Rendering/RenderOptionsPool.h
+++ b/source/runtime/Rendering/RenderOptionsPool.h
@@ -1,0 +1,148 @@
+﻿/*
+Copyright(c) 2015-2025 Panos Karabelas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+//= INCLUDES =================================
+#include "Renderer_Definitions.h"
+//============================================
+
+namespace spartan
+{
+    template<typename E>
+    constexpr auto enum_range()
+    {
+        return std::pair{E{0}, E::MAX};
+    }
+
+    template <typename T>
+    struct hash
+    {
+        std::enable_if_t<std::is_enum_v<T>, std::size_t>
+        operator()(T t) const noexcept
+        {
+            return static_cast<std::size_t>(t);
+        }
+    };
+
+    /*
+     * A class that encompasses all the rendering options settings.
+     * Option settings can be a mix of different global rendering properties
+     * or component related data, which include post-process, camera, world,
+     * weather, output, debugging and more.
+     * This is a scalable system that can work for different parameter collection
+     * methods.
+     */
+    class RenderOptionsPool
+    {
+    private:
+        std::map<Renderer_Option, RenderOptionType> m_options;
+    public:
+        RenderOptionsPool();
+        RenderOptionsPool(const std::map<Renderer_Option, RenderOptionType>& options);
+        RenderOptionsPool(RenderOptionsPool& other); // Move version
+        ~RenderOptionsPool() = default;
+
+        // Options map
+        std::map<Renderer_Option, RenderOptionType> GetOptions() const { return m_options;}
+        void SetOptions(const std::map<Renderer_Option, RenderOptionType>& options) { m_options = options; }
+
+        bool operator!=(const RenderOptionsPool& other) const;
+
+        static std::string EnumToString(Renderer_Option option); // used most likely for editor-related applications
+        static Renderer_Option StringToEnum(const std::string& name);
+
+        void SetOption(Renderer_Option option, const RenderOptionType& value);
+
+        RenderOptionType GetOption(const Renderer_Option option) const { return m_options.at(option); }
+
+        // Getters in the form of templates
+        template<typename T>
+        T GetOption(Renderer_Option option)
+        {
+            auto it = m_options.find(option);
+            if (it == m_options.end())
+            {
+                return T{}; // default fallback for specific value type
+            }
+
+            auto& variant_value = it->second;
+
+            if constexpr (std::is_enum_v<T>) // T is an enum: cast
+            {
+                return std::holds_alternative<uint32_t>(variant_value) ? static_cast<T>(std::get<uint32_t>(variant_value)) : T{};
+            }
+            else // T is bool, int, float
+            {
+                return std::holds_alternative<T>(variant_value) ? std::get<T>(variant_value) : T{};
+            }
+        }
+        template<typename T>
+        T& GetOptionRef(Renderer_Option option)
+        {
+            auto it = m_options.find(option);
+            if (it == m_options.end())
+            {
+                throw std::out_of_range("Option not found");
+            }
+
+            auto& variant_value = it->second;
+
+            if constexpr (!std::is_enum_v<T>) // bool, int, float
+            {
+                return std::get<T>(variant_value);
+            }
+            else
+            {
+                static T dummy{}; // fallback for enums (can't reference the cast)
+                return dummy;     // or throw / handle separately
+            }
+        }
+
+        template<typename... Ts>
+        static bool AreVariantsEqual(const std::variant<Ts...>& a, const std::variant<Ts...>& b)
+        {
+            // Fast path: if the active types differ, they cannot be equal
+            if (a.index() != b.index())
+                return false;
+
+            // Compare only if they hold the same type
+            return std::visit([]<typename T0, typename T1>(T0&& lhs, T1&& rhs) -> bool
+            {
+                using T = std::decay_t<T0>;
+
+                // Check that both are the same type at compile time
+                if constexpr (std::is_same_v<T, std::decay_t<T1>>)
+                {
+                    // For floats, use epsilon comparison to avoid precision errors
+                    if constexpr (std::is_floating_point_v<T>)
+                        return std::fabs(lhs - rhs) < 1e-6f;
+                    else
+                        return lhs == rhs;
+                }
+                else
+                {
+                    return false; // Different types — not equal
+                }
+            }, a, b);
+        }
+    };
+}

--- a/source/runtime/Rendering/Renderer.h
+++ b/source/runtime/Rendering/Renderer.h
@@ -31,6 +31,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "../Font/Font.h"
 #include <unordered_map>
 #include <atomic>
+#include "RenderOptionsPool.h"
 #include "../Math/Rectangle.h"
 //===============================
 
@@ -74,12 +75,13 @@ namespace spartan
         static void DrawString(const char* text, const math::Vector2& position_screen_percentage);
         static void DrawIcon(RHI_Texture* icon, const math::Vector2& position_screen_percentage);
 
-        // options
-        template<typename T>
-        static T GetOption(const Renderer_Option option) { return static_cast<T>(GetOptions()[option]); }
-        static void SetOption(Renderer_Option option, float value);
-        static std::unordered_map<Renderer_Option, float>& GetOptions();
-        static void SetOptions(const std::unordered_map<Renderer_Option, float>& options);
+        // render options
+        static RenderOptionType GetOption(const Renderer_Option option, const bool is_options_editor = false) { return is_options_editor ? editor_options.GetOption(option) : global_options.GetOption(option); }
+        template<typename T> static T GetOption(const Renderer_Option option, bool is_options_editor = false) { return is_options_editor ? editor_options.GetOption<T>(option) : global_options.GetOption<T>(option); }
+        template<typename T> static T& GetOptionRef(const Renderer_Option option, bool is_options_editor = false) { return is_options_editor ? editor_options.GetOptionRef<T>(option) : global_options.GetOptionRef<T>(option); }
+        static void SetOption(const Renderer_Option option, const RenderOptionType& value, const bool is_options_editor = false) { return is_options_editor ? editor_options.SetOption(option, value) : global_options.SetOption(option, value); }
+        static RenderOptionsPool GetRenderOptionsPool(const bool is_options_editor = false) { return is_options_editor ? editor_options : global_options; }
+        static RenderOptionsPool& GetRenderOptionsPoolRef(const bool is_options_editor = false) { return is_options_editor ? editor_options : global_options; }
 
         // swapchain
         static RHI_SwapChain* GetSwapChain();
@@ -203,6 +205,7 @@ namespace spartan
         static void UpdateShadowAtlas();
         static void UpdateDrawCalls(RHI_CommandList* cmd_list);
         static void UpdateAccelerationStructures(RHI_CommandList* cmd_list);
+        static void ApplyRenderOptions();
 
         // draw calls
         static std::array<Renderer_DrawCall, renderer_max_draw_calls> m_draw_calls;
@@ -217,6 +220,9 @@ namespace spartan
         static bool m_bindless_samplers_dirty;
 
         // misc
+        static RenderOptionsPool global_options;
+        static RenderOptionsPool editor_options;
+        static bool is_override_options;
         static Cb_Frame m_cb_frame_cpu;
         static Pcb_Pass m_pcb_pass_cpu;
         static std::shared_ptr<RHI_Buffer> m_lines_vertex_buffer;

--- a/source/runtime/Rendering/Renderer_Definitions.h
+++ b/source/runtime/Rendering/Renderer_Definitions.h
@@ -31,6 +31,8 @@ namespace spartan
     const uint32_t renderer_max_draw_calls          = 20000;
     const uint32_t renderer_max_instance_count      = 1024;
 
+    using RenderOptionType = std::variant<bool, int, float, uint32_t>;
+
     enum class Renderer_Option : uint32_t
     {
         Aabb,


### PR DESCRIPTION
Before submitting the volume component code, I think it would be a better idea to create a pre-phase PR for the renderer options upgrade.

- [x] Create a class specific for the renderer options and pool all the options in it
- [x] Create new definition for render options `std::variant<bool, int, float, uint32_t>` that handles all types separately
- [x] Separate the options between editor and renderer. Beneficial for future override features (such as the volume component)
- [x] Create third column in Render Options Editor Widget that separates Editor and Renderer values
- [x] Create missing widget handling for different types of render options in editor (ex: slider option)
- [x] Move all render options code from the Renderer class to the RenderOptionsPool class (debloats the Renderer)
- [x] Create override functionality that disabled Editor-Renderer connection if there is any override applied to the Renderer (kind of like a spoofer). **Future overrides can be handled separately, decoupling any future functionality from the Renderer completely.**

A view of the separation between Editor and Renderer options applied. Editor options apply to the Renderer if and only if the override is disabled and there are any different values between options (`AreVariantsEqual(...)`)
<img width="1762" height="731" alt="image" src="https://github.com/user-attachments/assets/cc9f82a3-7c92-4985-94f5-7795b547834a" />


What will be done next in another PR once this one gets merged in:
- [ ] Separate which options can be overridden and which not (I'm not expecting everything to be overridden by the Volume component, for example)
- [ ] Merge Volume Component code in another PR.

