### PR TITLE
Volume Component

### DIFF
--- a/source/editor/Widgets/Properties.cpp
+++ b/source/editor/Widgets/Properties.cpp
@@ -35,6 +35,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "World/Components/AudioSource.h"
 #include "World/Components/Terrain.h"
 #include "World/Components/Camera.h"
+#include "World/Components/Volume.h"
 //=======================================
 
 //= NAMESPACES =========
@@ -212,6 +213,7 @@ void Properties::OnTickVisible()
                 ShowRenderable(renderable);
                 ShowMaterial(material);
                 ShowPhysics(entity->GetComponent<Physics>());
+                ShowVolume(entity->GetComponent<Volume>());
 
                 ShowAddComponentButton();
             }
@@ -1169,6 +1171,132 @@ void Properties::ShowAudioSource(spartan::AudioSource* audio_source) const
     component_end();
 }
 
+void Properties::ShowVolume(Volume* volume) const
+{
+    if (!volume)
+        return;
+
+    const auto input_text_flags = ImGuiInputTextFlags_CharsDecimal;
+    const float step            = 0.1f;
+    const float step_fast       = 0.1f;
+    const auto precision        = "%.3f";
+
+    if (component_begin("Volume", volume))
+    {
+        // reflect
+        unordered_map<Renderer_Option, RenderOptionType> options                = volume->GetOptions();
+        float shape_size                                                        = volume->GetShapeSize();
+        float transition_size                                                   = volume->GetTransitionSize();
+        bool  is_debug_draw_enabled                                             = volume->GetDebugDrawEnabled();
+
+        if (ImGuiSp::collapsing_header("Volume Properties", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            // Mesh Type
+            {
+                static vector<string> body_types =
+                {
+                    "Box",
+                    "Sphere"
+                };
+
+                ImGui::Text("Volume Type");
+                ImGuiSp::tooltip("The body shape of the volume");
+                ImGui::SameLine(column_pos_x);
+                uint32_t selection_index = static_cast<uint32_t>(volume->GetVolumeShapeType());
+                if (ImGuiSp::combo_box("##volume_body_shape", body_types, &selection_index))
+                {
+                    volume->SetMeshType(static_cast<VolumeType>(selection_index));
+                }
+            }
+
+            // shape size
+            ImGui::Text("Volume Size");
+            ImGuiSp::tooltip("Size of inner volume shape (yellow)");
+            ImGui::SameLine(column_pos_x);
+            if (ImGui::InputFloat("##collisionShapeSize", &shape_size, step, step_fast, precision, input_text_flags))
+            {
+                // clamp to positive
+                shape_size = std::max(shape_size, default_shape_size);
+            }
+
+            // transition size
+            ImGui::Text("Transition Size");
+            ImGuiSp::tooltip("Thickness of outer volume shape (blue)");
+            ImGui::SameLine(column_pos_x);
+            if (ImGui::InputFloat("##collisionTransitionSize", &transition_size, step, step_fast, precision, input_text_flags))
+            {
+                // clamp to positive
+                transition_size = std::max(transition_size, default_transition_size);
+            }
+
+            // toggle for debug draw enabled
+            if (ImGui::Checkbox("Debug Draw Shape", &is_debug_draw_enabled))
+            {
+                volume->SetDebugDrawEnabled(is_debug_draw_enabled);
+            }
+            ImGuiSp::tooltip("Make volume shape outlines visible for debugging");
+        }
+
+        // Render Options
+        if (ImGuiSp::collapsing_header("Render Options", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            for (auto& [option_key, option_value] : options)
+            {
+                string label_str = Volume::RenderOptionToString(option_key);
+                const char* label = label_str.c_str();
+
+                if (std::holds_alternative<bool>(option_value))
+                {
+                    bool& bool_value = get<bool>(option_value);
+                    if (ImGui::Checkbox(label, &bool_value))
+                    {
+                        options[option_key] = bool_value;
+                    }
+                }
+                else if (std::holds_alternative<uint32_t>(option_value))
+                {
+                    uint32_t& enumValue = std::get<uint32_t>(option_value);
+
+                    if (option_key == Renderer_Option::Tonemapping)
+                    {
+                        const char* tonemapping_items[] = { "Aces", "AgX", "Reinhard", "AcesNautilus" };
+                        int current = static_cast<int>(enumValue);
+
+                        if (ImGui::Combo(label, &current, tonemapping_items, IM_ARRAYSIZE(tonemapping_items)))
+                        {
+                            enumValue = static_cast<uint32_t>(current);
+                            options[option_key] = enumValue;
+                        }
+                    }
+                }
+                else if (std::holds_alternative<float>(option_value))
+                {
+                    float& float_value = get<float>(option_value);
+                    if (ImGui::InputFloat(label, &float_value, 1, 0.1f))
+                    {
+                        options[option_key] = float_value;
+                    }
+                }
+                else if (std::holds_alternative<int>(option_value))
+                {
+                    int& int_value = get<int>(option_value);
+                    if (ImGui::InputInt(label, &int_value, 1, 0.0f))
+                    {
+                        options[option_key] = int_value;
+                    }
+                }
+            }
+        }
+
+        //= MAP ===================================================================================================================
+        if (fabs(shape_size - volume->GetShapeSize())           > epsilon) volume->SetShapeSize(shape_size);
+        if (fabs(transition_size - volume->GetTransitionSize()) > epsilon) volume->SetTransitionSize(transition_size);
+        if (options != volume->GetOptions())                                   volume->SetOptions(options);
+        //=========================================================================================================================
+    }
+    component_end();
+}
+
 void Properties::ShowAddComponentButton() const
 {
     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5);
@@ -1232,6 +1360,11 @@ void Properties::ComponentContextMenu_Add() const
                 }
 
                 ImGui::EndMenu();
+            }
+
+            if (ImGui::MenuItem("Volume"))
+            {
+                entity->AddComponent<Volume>();
             }
         }
 

--- a/source/editor/Widgets/Properties.h
+++ b/source/editor/Widgets/Properties.h
@@ -40,6 +40,7 @@ namespace spartan
     class AudioSource;
     class Script;
     class Terrain;
+    class Volume;
     class ReflectionProbe;
     class Component;
 }
@@ -66,6 +67,7 @@ private:
     void ShowCamera(spartan::Camera* camera) const;
     void ShowTerrain(spartan::Terrain* terrain) const;
     void ShowAudioSource(spartan::AudioSource* audio_source) const;
+    void ShowVolume(spartan::Volume* volume) const;
 
     void ShowAddComponentButton() const;
     void ComponentContextMenu_Add() const;

--- a/source/editor/Widgets/RenderOptions.cpp
+++ b/source/editor/Widgets/RenderOptions.cpp
@@ -77,9 +77,9 @@ namespace
 
         option_second_column();
         ImGui::PushID(static_cast<int>(ImGui::GetCursorPosY()));
-        bool value = Renderer::GetOption<bool>(render_option);
+        bool value = Renderer::GetOption<bool>(render_option, true);
         ImGui::Checkbox("", &value);
-        Renderer::SetOption(render_option, value);
+        Renderer::SetOption(render_option, value, true);
         ImGui::PopID();
     }
 
@@ -128,7 +128,7 @@ namespace
         bool changed = false;
         option_second_column();
         {
-            float value = Renderer::GetOption<float>(render_option);
+            float value = Renderer::GetOption<float>(render_option, true);
 
             ImGui::PushID(static_cast<int>(ImGui::GetCursorPosY()));
             ImGui::PushItemWidth(width_input_numeric);
@@ -138,9 +138,9 @@ namespace
             value = clamp(value, min, max);
 
             // Only update if changed
-            if (Renderer::GetOption<float>(render_option) != value)
+            if (changed)
             {
-                Renderer::SetOption(render_option, value);
+                Renderer::SetOption(render_option, value, true);
             }
         }
 
@@ -255,7 +255,7 @@ void RenderOptions::OnTickVisible()
                     option_check_box("Variable rate shading", Renderer_Option::VariableRateShading, "Improves performance by varying shading detail per pixel");
                     option_check_box("Dynamic resolution", Renderer_Option::DynamicResolution, "Scales render resolution automatically based on GPU load");
 
-                    ImGui::BeginDisabled(Renderer::GetOption<bool>(Renderer_Option::DynamicResolution));
+                    ImGui::BeginDisabled(Renderer::GetOption<bool>(Renderer_Option::DynamicResolution, true));
                     option_value("Resolution scale", Renderer_Option::ResolutionScale, "Adjusts the percentage of the render resolution", 0.01f);
                     ImGui::EndDisabled();
                 }
@@ -272,13 +272,13 @@ void RenderOptions::OnTickVisible()
 
                     Vector2 res_render = Renderer::GetResolutionRender();
                     Vector2 res_output = Renderer::GetResolutionOutput();
-                    uint32_t mode      = Renderer::GetOption<uint32_t>(Renderer_Option::AntiAliasing_Upsampling);
+                    uint32_t mode      = Renderer::GetOption<uint32_t>(Renderer_Option::AntiAliasing_Upsampling, true);
                     if (option_combo_box("Upsampling method", upsamplers, mode))
                     {
-                        Renderer::SetOption(Renderer_Option::AntiAliasing_Upsampling, static_cast<float>(mode));
+                        Renderer::SetOption(Renderer_Option::AntiAliasing_Upsampling, static_cast<float>(mode), true);
                     }
 
-                    bool use_rcas = Renderer::GetOption<Renderer_AntiAliasing_Upsampling>(Renderer_Option::AntiAliasing_Upsampling) == Renderer_AntiAliasing_Upsampling::AA_Fsr_Upscale_Fsr;
+                    bool use_rcas = Renderer::GetOption<Renderer_AntiAliasing_Upsampling>(Renderer_Option::AntiAliasing_Upsampling, true) == Renderer_AntiAliasing_Upsampling::AA_Fsr_Upscale_Fsr;
                     string label = use_rcas ? "Sharpness (RCAS)" : "Sharpness (CAS)";
                     string tooltip = use_rcas ? "AMD FidelityFX Robust Contrast Adaptive Sharpening" : "AMD FidelityFX Contrast Adaptive Sharpening";
                     option_value(label.c_str(), Renderer_Option::Sharpness, tooltip.c_str(), 0.1f, 0.0f, 1.0f);
@@ -316,12 +316,12 @@ void RenderOptions::OnTickVisible()
                 if (option("Display"))
                 {
                     option_check_box("HDR", Renderer_Option::Hdr, "Enable high dynamic range output");
-                    ImGui::BeginDisabled(Renderer::GetOption<bool>(Renderer_Option::Hdr));
+                    ImGui::BeginDisabled(Renderer::GetOption<bool>(Renderer_Option::Hdr, true));
                     option_value("Gamma", Renderer_Option::Gamma);
                     ImGui::EndDisabled();
                     option_value("Exposure adaptation speed", Renderer_Option::AutoExposureAdaptationSpeed, "Negative value disables adaptation");
 
-                    bool hdr_enabled = Renderer::GetOption<bool>(Renderer_Option::Hdr);
+                    bool hdr_enabled = Renderer::GetOption<bool>(Renderer_Option::Hdr, true);
                     ImGui::BeginDisabled(!hdr_enabled);
                     option_value("White point (nits)", Renderer_Option::WhitePoint, "Target luminance of peak white", 1.0f);
                     ImGui::EndDisabled();
@@ -330,10 +330,10 @@ void RenderOptions::OnTickVisible()
                 if (option("Tone Mapping"))
                 {
                     static vector<string> tonemapping = { "ACES", "AgX", "Reinhard", "ACES Nautilus", "Off" };
-                    uint32_t index = Renderer::GetOption<uint32_t>(Renderer_Option::Tonemapping);
+                    uint32_t index = Renderer::GetOption<uint32_t>(Renderer_Option::Tonemapping, true);
                     if (option_combo_box("Algorithm", tonemapping, index))
                     {
-                        Renderer::SetOption(Renderer_Option::Tonemapping, static_cast<float>(index));
+                        Renderer::SetOption(Renderer_Option::Tonemapping, static_cast<float>(index), true);
                     }
                 }
 

--- a/source/editor/Widgets/WorldViewer.cpp
+++ b/source/editor/Widgets/WorldViewer.cpp
@@ -33,6 +33,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "Commands/CommandStack.h"
 #include "Input/Input.h"
 #include "../ImGui/ImGui_Extension.h"
+#include "World/Components/Volume.h"
 SP_WARNINGS_OFF
 #include "../ImGui/Source/imgui_stdlib.h"
 SP_WARNINGS_ON
@@ -563,6 +564,12 @@ void WorldViewer::PopupContextMenu() const
         ActionEntityCreateTerrain();
     }
 
+    // VOLUME
+    if (ImGui::MenuItem("Volume"))
+    {
+        ActionEntityCreateVolume();
+    }
+
     ImGui::EndPopup();
 }
 
@@ -777,4 +784,11 @@ void WorldViewer::ActionEntityCreateAudioSource()
     auto entity = ActionEntityCreateEmpty();
     entity->AddComponent<spartan::AudioSource>();
     entity->SetObjectName("Physics");
+}
+
+void WorldViewer::ActionEntityCreateVolume()
+{
+    auto entity = ActionEntityCreateEmpty();
+    entity->AddComponent<spartan::Volume>();
+    entity->SetObjectName("Volume");
 }

--- a/source/editor/Widgets/WorldViewer.h
+++ b/source/editor/Widgets/WorldViewer.h
@@ -65,4 +65,5 @@ private:
     static void ActionEntityCreateLightSpot();
     static void ActionEntityCreatePhysicsBody();
     static void ActionEntityCreateAudioSource();
+    static void ActionEntityCreateVolume();
 };

--- a/source/runtime/Math/Vector3.h
+++ b/source/runtime/Math/Vector3.h
@@ -117,6 +117,13 @@ namespace spartan::math
             return std::max(std::max(x, y), z);
         }
 
+        Vector3 Max(const Vector3& other)
+        {
+            return {std::max(x, other.x),
+                       std::max(y, other.y),
+                       std::max(z, other.z)};
+        }
+
         [[nodiscard]] static float Dot(const Vector3& v1, const Vector3& v2) 
         { 
             return (v1.x * v2.x + v1.y * v2.y + v1.z * v2.z);

--- a/source/runtime/Rendering/Renderer.h
+++ b/source/runtime/Rendering/Renderer.h
@@ -76,10 +76,12 @@ namespace spartan
 
         // options
         template<typename T>
-        static T GetOption(const Renderer_Option option) { return static_cast<T>(GetOptions()[option]); }
-        static void SetOption(Renderer_Option option, float value);
-        static std::unordered_map<Renderer_Option, float>& GetOptions();
-        static void SetOptions(const std::unordered_map<Renderer_Option, float>& options);
+        static T GetOption(const Renderer_Option option, bool is_option_editor = false) { return is_option_editor ? static_cast<T>(GetOptions(true)[option]) : static_cast<T>(GetOptions()[option]); }
+        static void SetOption(Renderer_Option option, float value, bool is_option_editor = false);
+        static std::unordered_map<Renderer_Option, float>& GetOptions(bool is_option_editor = false);
+        static void SetOptions(const std::unordered_map<Renderer_Option, float>& options, bool is_option_editor = false);
+        static void ApplyRenderOptions();
+        static void SetOverrideEnabled(bool is_override) { is_override_enabled = is_override; }
 
         // swapchain
         static RHI_SwapChain* GetSwapChain();
@@ -217,6 +219,9 @@ namespace spartan
         static bool m_bindless_samplers_dirty;
 
         // misc
+        static std::unordered_map<Renderer_Option, float> global_options;
+        static std::unordered_map<Renderer_Option, float> editor_options;
+        static bool is_override_enabled;
         static Cb_Frame m_cb_frame_cpu;
         static Pcb_Pass m_pcb_pass_cpu;
         static std::shared_ptr<RHI_Buffer> m_lines_vertex_buffer;

--- a/source/runtime/World/Components/Component.cpp
+++ b/source/runtime/World/Components/Component.cpp
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "Camera.h"
 #include "AudioSource.h"
 #include "Terrain.h"
+#include "Volume.h"
 //======================
 
 //= NAMESPACES =====
@@ -56,4 +57,5 @@ namespace spartan
     REGISTER_COMPONENT(Renderable,  ComponentType::Renderable)
     REGISTER_COMPONENT(Physics,     ComponentType::Physics)
     REGISTER_COMPONENT(Terrain,     ComponentType::Terrain)
+    REGISTER_COMPONENT(Volume,      ComponentType::Volume)
 }

--- a/source/runtime/World/Components/Component.h
+++ b/source/runtime/World/Components/Component.h
@@ -46,6 +46,7 @@ namespace spartan
         Physics,
         Renderable,
         Terrain,
+        Volume,
         Max
     };
     // after re-ordering the above, ensure .world save/load works
@@ -113,7 +114,8 @@ namespace spartan
             if (name == "physics")      return ComponentType::Physics;
             if (name == "renderable")   return ComponentType::Renderable;
             if (name == "terrain")      return ComponentType::Terrain;
-        
+            if (name == "volume")       return ComponentType::Volume;
+
             assert(false && "StringToType: Unknown component name");
             return ComponentType::Max;
         }

--- a/source/runtime/World/Components/Volume.cpp
+++ b/source/runtime/World/Components/Volume.cpp
@@ -1,0 +1,378 @@
+/*
+Copyright(c) 2015-2025 Panos Karabelas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+//= INCLUDES =================================
+#include "pch.h"
+#include "IO/pugixml.hpp"
+
+#include <algorithm>
+
+#include "Camera.h"
+#include "Rendering/Renderer.h"
+#include "World/Entity.h"
+#include "Volume.h"
+
+#include "Display/Display.h"
+//============================================
+
+//= NAMESPACES ===============
+using namespace std;
+using namespace spartan::math;
+//============================
+
+namespace spartan
+{
+    unordered_map<Renderer_Option, RenderOptionType> Volume::global_render_options;
+    unordered_map<Renderer_Option, const char*> Volume::options_labels;
+    unordered_map<Renderer_Option, RenderOptionType> Volume::blended_options; // volume data accumulation (on interpolation)
+    unordered_map<Renderer_Option, float> Volume::accumulator_floats {};
+    unordered_map<Renderer_Option, float> Volume::accumulator_weights {};
+    int Volume::overlapping_count = 0;
+    uint64_t Volume::accumulation_frame = UINT64_MAX;
+    uint64_t Volume::finalization_frame = UINT64_MAX;
+
+    Volume::Volume(Entity* entity) : Component(entity)
+    {
+        SP_REGISTER_ATTRIBUTE_VALUE_VALUE(m_volume_shape_type, VolumeType);
+        SP_REGISTER_ATTRIBUTE_VALUE_VALUE(m_shape_size, float);
+        SP_REGISTER_ATTRIBUTE_VALUE_VALUE(m_transition_size, float);
+        SP_REGISTER_ATTRIBUTE_VALUE_VALUE(m_is_debug_draw_enabled, bool);
+
+        m_volume_shape_type = VolumeType::Sphere;
+        m_bounding_box = BoundingBox::Unit;
+        m_shape_size = default_shape_size;
+        m_transition_size = default_transition_size;
+        m_is_debug_draw_enabled = true;
+
+        m_options.clear();
+        m_options[Renderer_Option::WhitePoint] = RenderOptionType { 350.0f };
+        m_options[Renderer_Option::Tonemapping] = RenderOptionType { static_cast<float>(Renderer_Tonemapping::Max) };
+        m_options[Renderer_Option::Bloom] = RenderOptionType { 1.0f };
+        m_options[Renderer_Option::MotionBlur] = RenderOptionType { true };
+        m_options[Renderer_Option::DepthOfField] = RenderOptionType { true };
+        m_options[Renderer_Option::ScreenSpaceAmbientOcclusion] = RenderOptionType { true };
+        m_options[Renderer_Option::ScreenSpaceReflections] = RenderOptionType { true };
+        m_options[Renderer_Option::RayTracedReflections] = RenderOptionType { false };
+        m_options[Renderer_Option::Anisotropy] = RenderOptionType { 16.0f };
+        m_options[Renderer_Option::Sharpness] = RenderOptionType { 0.0f };
+        m_options[Renderer_Option::Fog] = RenderOptionType { 1.0f };
+        m_options[Renderer_Option::AntiAliasing_Upsampling] = RenderOptionType { static_cast<uint32_t>(Renderer_AntiAliasing_Upsampling::AA_Fsr_Upscale_Fsr) };
+        m_options[Renderer_Option::ResolutionScale] = RenderOptionType { 1.0f };
+        m_options[Renderer_Option::VariableRateShading] = RenderOptionType { false };
+        m_options[Renderer_Option::Vsync] = RenderOptionType { false };
+        m_options[Renderer_Option::TransformHandle] = RenderOptionType { true };
+        m_options[Renderer_Option::SelectionOutline] = RenderOptionType { false };
+        m_options[Renderer_Option::Grid] = RenderOptionType { false };
+        m_options[Renderer_Option::Lights] = RenderOptionType { true };
+        m_options[Renderer_Option::AudioSources] = RenderOptionType { true };
+        m_options[Renderer_Option::Physics] = RenderOptionType { false };
+        m_options[Renderer_Option::PerformanceMetrics] = RenderOptionType { true };
+        m_options[Renderer_Option::Gamma] = RenderOptionType { Display::GetGamma() };
+        m_options[Renderer_Option::AutoExposureAdaptationSpeed] = RenderOptionType { 0.5f };
+    }
+
+    Volume::~Volume()
+    {
+
+    }
+
+    const char* Volume::RenderOptionToString(const Renderer_Option option)
+    {
+        // Options labelled the same way as the Render Options editor view
+        switch (option)
+        {
+            case Renderer_Option::Aabb:                        return "AABBs";
+            case Renderer_Option::PickingRay:                  return "Picking ray";
+            case Renderer_Option::Grid:                        return "Grid";
+            case Renderer_Option::TransformHandle:             return "Transform handles";
+            case Renderer_Option::SelectionOutline:            return "Selection outline";
+            case Renderer_Option::Lights:                      return "Lights";
+            case Renderer_Option::AudioSources:                return "Audio sources";
+            case Renderer_Option::PerformanceMetrics:          return "Show performance Metrics";
+            case Renderer_Option::Physics:                     return "Physics";
+            case Renderer_Option::Wireframe:                   return "Wireframe";
+            case Renderer_Option::Bloom:                       return "Bloom";
+            case Renderer_Option::Fog:                         return "Fog";
+            case Renderer_Option::ScreenSpaceAmbientOcclusion: return "Ambient Occlusion (SSR)";
+            case Renderer_Option::ScreenSpaceReflections:      return "Reflections (SSR)";
+            case Renderer_Option::MotionBlur:                  return "Motion blur";
+            case Renderer_Option::DepthOfField:                return "Depth of field";
+            case Renderer_Option::FilmGrain:                   return "Film grain";
+            case Renderer_Option::ChromaticAberration:         return "Chromatic aberration";
+            case Renderer_Option::Anisotropy:                  return "Anisotropy";
+            case Renderer_Option::WhitePoint:                  return "White point (nits)";
+            case Renderer_Option::Tonemapping:                 return "Tone Mapping";
+            case Renderer_Option::AntiAliasing_Upsampling:     return "Anti-Aliasing Upsampling";
+            case Renderer_Option::Sharpness:                   return "Sharpness";
+            case Renderer_Option::Hdr:                         return "HDR";
+            case Renderer_Option::Gamma:                       return "Gamma";
+            case Renderer_Option::Vsync:                       return "VSync";
+            case Renderer_Option::VariableRateShading:         return "Variable rate shading";
+            case Renderer_Option::ResolutionScale:             return "Resolution scale";
+            case Renderer_Option::DynamicResolution:           return "Dynamic Resolution";
+            case Renderer_Option::Dithering:                   return "Dithering";
+            case Renderer_Option::Vhs:                         return "VHS";
+            case Renderer_Option::OcclusionCulling:            return "Occlusion culling";
+            case Renderer_Option::AutoExposureAdaptationSpeed: return "Exposure adaptation speed";
+            case Renderer_Option::RayTracedReflections:        return "Reflections (Ray-Traced)";
+            default:
+            {
+                SP_ASSERT_MSG(false, "Renderer_Option not handled");
+                return "";
+            }
+        }
+    }
+
+    void Volume::Save(pugi::xml_node& node)
+    {
+        node.append_attribute("shape_type")      = static_cast<int>(m_volume_shape_type);
+        node.append_attribute("shape_size")      = m_shape_size;
+        node.append_attribute("transition_size") = m_transition_size;
+        node.append_attribute("debug_enabled")   = m_is_debug_draw_enabled;
+    }
+
+    void Volume::Load(pugi::xml_node& node)
+    {
+        m_volume_shape_type = static_cast<VolumeType>(node.attribute("shape_type").as_int(static_cast<int>(VolumeType::Max)));
+        m_shape_size = node.attribute("shape_size").as_float();
+        m_transition_size = node.attribute("transition_size").as_float();
+        m_is_debug_draw_enabled = node.attribute("debug_enabled").as_bool();
+
+        m_bounding_box = BoundingBox::Unit;
+    }
+
+    void Volume::PreTick()
+    {
+        const uint64_t frame = Renderer::GetFrameNumber();
+
+        // Reset data only once per frame
+        if (accumulation_frame != frame)
+        {
+            accumulation_frame = frame;
+            accumulator_floats.clear();
+            accumulator_weights.clear();
+            overlapping_count = 0;
+
+            DecodeRenderOptions();
+            blended_options = global_render_options;
+        }
+
+        const Camera* camera = World::GetCamera();
+        if (!camera)
+            return;
+
+        const Vector3 cam_position = camera->GetEntity()->GetPosition();
+        const float alpha = ComputeAlpha(cam_position);
+
+        const bool is_overlapping_now = alpha > 0.0f;
+
+        // Override Renderer only when necessary (when the camera has entered at least one volume)
+        if (is_overlapping_now)
+        {
+            ++overlapping_count;
+            Renderer::SetOverrideEnabled(true);
+        }
+
+        if (!is_overlapping_now)
+            return;
+
+        AccumulateVolumeRenderOptions(alpha);
+    }
+
+    void Volume::Tick()
+    {
+        if (m_is_debug_draw_enabled)
+        {
+            DrawVolume();
+        }
+
+        const uint64_t frame = Renderer::GetFrameNumber();
+
+        // Finalize and apply data only once per frame
+        if (finalization_frame == frame)
+            return;
+
+        finalization_frame = frame;
+
+        if (overlapping_count == 0)
+        {
+            Renderer::SetOverrideEnabled(false);
+            return;
+        }
+
+        ApplyBlendedRenderOptions();
+    }
+
+    void Volume::DecodeRenderOptions()
+    {
+        // Get global render options set by the user
+        unordered_map<Renderer_Option, float> global_options = Renderer::GetOptions(true);
+
+        // Decode all options to their corresponding value type
+        MapFloatToRenderOption<float>(Renderer_Option::WhitePoint, global_options[Renderer_Option::WhitePoint]);
+        MapFloatToRenderOption<uint32_t>(Renderer_Option::Tonemapping, global_options[Renderer_Option::Tonemapping]);
+        MapFloatToRenderOption<float>(Renderer_Option::Bloom, global_options[Renderer_Option::Bloom]);
+        MapFloatToRenderOption<bool>(Renderer_Option::MotionBlur, global_options[Renderer_Option::MotionBlur]);
+        MapFloatToRenderOption<bool>(Renderer_Option::DepthOfField, global_options[Renderer_Option::DepthOfField]);
+        MapFloatToRenderOption<bool>(Renderer_Option::ScreenSpaceAmbientOcclusion, global_options[Renderer_Option::ScreenSpaceAmbientOcclusion]);
+        MapFloatToRenderOption<bool>(Renderer_Option::ScreenSpaceReflections, global_options[Renderer_Option::ScreenSpaceReflections]);
+        MapFloatToRenderOption<bool>(Renderer_Option::RayTracedReflections, global_options[Renderer_Option::RayTracedReflections]);
+        MapFloatToRenderOption<float>(Renderer_Option::Anisotropy, global_options[Renderer_Option::Anisotropy]);
+        MapFloatToRenderOption<float>(Renderer_Option::Sharpness, global_options[Renderer_Option::Sharpness]);
+        MapFloatToRenderOption<float>(Renderer_Option::Fog, global_options[Renderer_Option::Fog]);
+        MapFloatToRenderOption<uint32_t>(Renderer_Option::AntiAliasing_Upsampling, global_options[Renderer_Option::AntiAliasing_Upsampling]);
+        MapFloatToRenderOption<float>(Renderer_Option::ResolutionScale, global_options[Renderer_Option::ResolutionScale]);
+        MapFloatToRenderOption<bool>(Renderer_Option::VariableRateShading, global_options[Renderer_Option::VariableRateShading]);
+        MapFloatToRenderOption<bool>(Renderer_Option::Vsync, global_options[Renderer_Option::Vsync]);
+        MapFloatToRenderOption<bool>(Renderer_Option::TransformHandle, global_options[Renderer_Option::TransformHandle]);
+        MapFloatToRenderOption<bool>(Renderer_Option::SelectionOutline, global_options[Renderer_Option::SelectionOutline]);
+        MapFloatToRenderOption<bool>(Renderer_Option::Grid, global_options[Renderer_Option::Grid]);
+        MapFloatToRenderOption<bool>(Renderer_Option::Lights, global_options[Renderer_Option::Lights]);
+        MapFloatToRenderOption<bool>(Renderer_Option::AudioSources, global_options[Renderer_Option::AudioSources]);
+        MapFloatToRenderOption<bool>(Renderer_Option::Physics, global_options[Renderer_Option::Physics]);
+        MapFloatToRenderOption<bool>(Renderer_Option::PerformanceMetrics, global_options[Renderer_Option::PerformanceMetrics]);
+        MapFloatToRenderOption<bool>(Renderer_Option::Dithering, global_options[Renderer_Option::Dithering]);
+        MapFloatToRenderOption<bool>(Renderer_Option::Gamma, global_options[Renderer_Option::Gamma]);
+        MapFloatToRenderOption<float>(Renderer_Option::AutoExposureAdaptationSpeed, global_options[Renderer_Option::AutoExposureAdaptationSpeed]);
+    }
+
+    float Volume::MapRenderOptionToFloat(const RenderOptionType& value)
+    {
+        return std::visit([](auto&& v) -> float
+        {
+            using T = std::decay_t<decltype(v)>;
+
+            if constexpr (std::is_same_v<T, bool>)
+                return v ? 1.0f : 0.0f;
+            else if constexpr (std::is_same_v<T, int>)
+                return static_cast<float>(v);
+            else if constexpr (std::is_same_v<T, float>)
+                return v;
+            else if constexpr (std::is_same_v<T, uint32_t>)
+                return static_cast<float>(v);
+        }, value);
+    }
+
+    void Volume::AccumulateVolumeRenderOptions(const float alpha)
+    {
+        for (auto& [key, value] : m_options)
+        {
+            if (std::holds_alternative<float>(value))
+            {
+                const float v = std::get<float>(value);
+                accumulator_floats[key]  += v * alpha;
+                accumulator_weights[key] += alpha;
+            }
+            else
+            {
+                blended_options[key] = value;
+            }
+        }
+    }
+
+    void Volume::ApplyBlendedRenderOptions()
+    {
+        for (auto& [key, sum] : accumulator_floats)
+        {
+            const float weight = accumulator_weights[key];
+            if (weight <= 0.0f)
+                continue;
+
+            const float float_average = sum / weight;
+            const float global_float_option = MapRenderOptionToFloat(global_render_options[key]);
+
+            const float t = clamp(weight, 0.0f, 1.0f);
+
+            blended_options[key] = lerp(global_float_option, float_average, t);
+        }
+
+        // Apply to renderer only if values have changed
+        for (auto& [key, value] : blended_options)
+        {
+            float new_value = MapRenderOptionToFloat(value);
+            if (fabs(Renderer::GetOptions()[key] - new_value) > epsilon)
+            {
+                Renderer::SetOption(key, new_value);
+            }
+        }
+    }
+
+    void Volume::DrawVolume()
+    {
+        // For debugging
+        if (m_volume_shape_type == VolumeType::Sphere)
+        {
+            Renderer::DrawSphere(m_entity_ptr->GetPosition(), m_shape_size, 16, Color::standard_yellow);
+            Renderer::DrawSphere(m_entity_ptr->GetPosition(), m_shape_size + m_transition_size, 16, Color::standard_renderer_lines);
+        }
+        else if (m_volume_shape_type == VolumeType::Box)
+        {
+            const Matrix new_matrix_inner = Matrix(m_entity_ptr->GetPosition(), m_entity_ptr->GetRotation(), m_entity_ptr->GetScale() + m_shape_size);
+            Renderer::DrawBox(m_bounding_box * new_matrix_inner, Color::standard_yellow);
+
+            const Matrix new_matrix_outer = Matrix(m_entity_ptr->GetPosition(), m_entity_ptr->GetRotation(), m_entity_ptr->GetScale() + m_shape_size + m_transition_size);
+            Renderer::DrawBox(m_bounding_box * new_matrix_outer, Color::standard_renderer_lines);
+        }
+    }
+
+    float Volume::ComputeAlpha(const Vector3& camera_position) const
+    {
+        if (m_volume_shape_type == VolumeType::Box)
+        {
+            const Vector3 distance_absolute = (camera_position - m_entity_ptr->GetPosition()).Abs();
+
+            const Vector3 inner_half_extents = m_bounding_box.GetExtents() + Vector3(m_shape_size / 2.0f);
+            const Vector3 outer_half_extents = inner_half_extents + Vector3(m_transition_size);
+
+            const float dist_to_inner = (distance_absolute - inner_half_extents).Max(Vector3::Zero).Length();
+            const float dist_to_outer = (distance_absolute - outer_half_extents).Max(Vector3::Zero).Length();
+
+            if (dist_to_inner <= 0.0f)
+            {
+                return 1.0f;
+            }
+            if (dist_to_outer > 0.0f)
+            {
+                return 0.0f;
+            }
+
+            return 1.0f - dist_to_inner / m_transition_size;
+        }
+        if (m_volume_shape_type == VolumeType::Sphere)
+        {
+            const float distance = Vector3::Distance(camera_position, m_entity_ptr->GetPosition());
+
+            if (distance > m_transition_size + m_shape_size)
+            {
+                return 0.0f;
+            }
+            if (distance <= m_shape_size)
+            {
+                return 1.0f;
+            }
+
+            return 1.0f - (distance - m_shape_size) / m_transition_size;
+        }
+
+        // Unknown shape. Reset to hard transition.
+        return 1.0f;
+    }
+}

--- a/source/runtime/World/Components/Volume.h
+++ b/source/runtime/World/Components/Volume.h
@@ -1,0 +1,137 @@
+﻿/*
+Copyright(c) 2015-2025 Panos Karabelas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions :
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+//= INCLUDES =================================
+#include "Component.h"
+//============================================
+
+namespace spartan
+{
+    using RenderOptionType = std::variant<bool, int, float, uint32_t>;
+
+    static constexpr float default_shape_size = 1.0f;
+    static constexpr float default_transition_size = 0.2f;
+
+    enum class VolumeType
+    {
+        Box,
+        Sphere,
+        Max
+    };
+
+    /*
+     * A component that handles local overrides of global components.
+     * A volume contains a map of each component with a list of its registered attributes.
+     * Static data help with managing and accumulating data from multiple volumes at once
+     * and avoid repeated actions per frame.
+     */
+    class Volume : public Component
+    {
+    private:
+        //===== STATIC DATA FOR VOLUME MANAGEMENT =====
+        static std::unordered_map<Renderer_Option, RenderOptionType> global_render_options;
+        static std::unordered_map<Renderer_Option, const char*> options_labels;
+
+        static std::unordered_map<Renderer_Option, RenderOptionType> blended_options; // volume data accumulation (on interpolation)
+        static std::unordered_map<Renderer_Option, float> accumulator_floats;
+        static std::unordered_map<Renderer_Option, float> accumulator_weights;
+        static int overlapping_count;
+        static uint64_t accumulation_frame;
+        static uint64_t finalization_frame;
+        //=============================================
+
+        VolumeType m_volume_shape_type   = VolumeType::Sphere;
+        float m_shape_size               = default_shape_size;
+        float m_transition_size          = default_transition_size;
+        bool m_is_debug_draw_enabled     = true;
+
+        math::BoundingBox m_bounding_box = math::BoundingBox::Unit;
+
+        std::unordered_map<Renderer_Option, RenderOptionType> m_options;
+
+        // Option mapping functions
+        static void DecodeRenderOptions();
+        static float MapRenderOptionToFloat(const RenderOptionType& option);
+        template<typename T>
+        static void MapFloatToRenderOption(Renderer_Option option, float value)
+        {
+            static_assert(std::is_same_v<T, bool> || std::is_same_v<T, int> || std::is_same_v<T, float> || std::is_same_v<T, uint32_t>, "Type not supported by RenderOptionType");
+
+            if constexpr (std::is_same_v<T, bool>)
+            {
+                global_render_options[option] = RenderOptionType{ std::in_place_type<bool>, value != 0.0f };
+            }
+            else if constexpr (std::is_same_v<T, int>)
+            {
+                global_render_options[option] = RenderOptionType{ std::in_place_type<int>, static_cast<int>(value) };
+            }
+            else if constexpr (std::is_same_v<T, float>)
+            {
+                global_render_options[option] = RenderOptionType{ value };
+            }
+            else if constexpr (std::is_same_v<T, uint32_t>)
+            {
+                const float clamped = std::clamp(value, 0.0f, static_cast<float>(std::numeric_limits<uint32_t>::max()));
+                global_render_options[option] = RenderOptionType{ std::in_place_type<uint32_t>, static_cast<uint32_t>(clamped) };
+            }
+        }
+
+        void AccumulateVolumeRenderOptions(float alpha);
+        static void ApplyBlendedRenderOptions();
+        float ComputeAlpha(const math::Vector3& camera_position) const;
+
+        void DrawVolume();
+    public:
+        Volume(Entity* entity);
+        ~Volume() override;
+
+        static const char* RenderOptionToString(const Renderer_Option option);
+
+        //= COMPONENT ================================
+        void PreTick() override;
+        void Tick() override;
+        void Save(pugi::xml_node& node) override;
+        void Load(pugi::xml_node& node) override;
+        //============================================
+
+        // Options
+        std::unordered_map<Renderer_Option, RenderOptionType> GetOptions() const { return m_options; }
+        void SetOptions(std::unordered_map<Renderer_Option, RenderOptionType> options) { m_options = options; }
+
+        // Mesh Type
+        VolumeType GetVolumeShapeType() const { return m_volume_shape_type; }
+        void SetMeshType(const VolumeType volume_type) { m_volume_shape_type = volume_type; }
+
+        // Shape size
+        float GetShapeSize() const { return m_shape_size; }
+        void SetShapeSize(const float shape_size) { m_shape_size = shape_size; }
+
+        // Transition size
+        float GetTransitionSize() const { return m_transition_size; }
+        void SetTransitionSize(const float transition_size) { m_transition_size = transition_size; }
+
+        // Debug Draw
+        bool GetDebugDrawEnabled() const { return m_is_debug_draw_enabled; }
+        void SetDebugDrawEnabled(bool value) { m_is_debug_draw_enabled = value; }
+    };
+}


### PR DESCRIPTION
Created a capable and modular volume component with the least amount of changes necessary in the engine. All the volume's functionality has remained intact in its own class file.

- [x] Create an intact volume component system
- [x] Support overlapping and blending of multiple volumes using static data
- [x] Implement volume resizing and  debug view of different shapes (box, sphere)
- [x] Implement render options in the component's properties panel for overridding
- [x] Separate editor-controlled render options from final applied render options. I had no choice but to separate the global from the final values (or else we cannot perform any temporary overrides), so I added an additional options map. **Nothing else changes, except accommodating the new map in the getter and setter option functions.**

If things need to be improved, I am open for specific code suggestions or give the opportunity to someone else to try a different approach.